### PR TITLE
Split Trade Manager

### DIFF
--- a/java/src/main/java/org/psu/init/ShipLoader.java
+++ b/java/src/main/java/org/psu/init/ShipLoader.java
@@ -22,6 +22,7 @@ import org.psu.spacetraders.dto.ShipNavigation;
 import org.psu.spacetraders.dto.Waypoint;
 import org.psu.trademanager.MarketplaceManager;
 import org.psu.trademanager.TradeShipManager;
+import org.psu.trademanager.dto.TradeShipJob;
 
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -95,7 +96,12 @@ public class ShipLoader {
     	// TODO: Make the mining ship manager so we're not sending the mining ship to the trading manager
 		final Ship tradeShip = ships.stream().filter(s -> ShipRole.MINING.equals(shipRoleManager.determineRole(s)))
 				.findFirst().get();
-		tradeShipManager.manageTradeShip(tradeShip);
+
+		// Manage the job three times, TODO hook this up to a queue
+		final TradeShipJob job = tradeShipManager.createJob(tradeShip);
+		tradeShipManager.manageTradeShip(job);
+		tradeShipManager.manageTradeShip(job);
+		tradeShipManager.manageTradeShip(job);
 	}
 
     public List<Ship> gatherShips() {

--- a/java/src/main/java/org/psu/trademanager/RouteManager.java
+++ b/java/src/main/java/org/psu/trademanager/RouteManager.java
@@ -72,7 +72,7 @@ public class RouteManager {
 			buildTradeRoutes();
 		}
 
-		// The route whose total travel distance for the ship is smalled
+		// The route whose total travel distance for the ship is smallest
 		// Filter out impossible routes
 		return this.tradeRoutes.stream().filter(t -> t.isPossible(ship))
 				.min((tr1, tr2) -> Double.compare(ship.distTo(tr1.getExportWaypoint()) + tr1.getDistance(),

--- a/java/src/main/java/org/psu/trademanager/TradeShipManager.java
+++ b/java/src/main/java/org/psu/trademanager/TradeShipManager.java
@@ -18,7 +18,10 @@ import org.psu.spacetraders.dto.Ship;
 import org.psu.spacetraders.dto.ShipNavigation;
 import org.psu.spacetraders.dto.TradeRequest;
 import org.psu.spacetraders.dto.TradeResponse;
+import org.psu.spacetraders.dto.Waypoint;
 import org.psu.trademanager.dto.TradeRoute;
+import org.psu.trademanager.dto.TradeShipJob;
+import org.psu.trademanager.dto.TradeShipJob.State;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -51,97 +54,129 @@ public class TradeShipManager {
 		this.routeManager = routeManager;
 	}
 
+	public TradeShipJob createJob(final Ship ship) {
+		final TradeRoute closestRoute = routeManager.getClosestRoute(ship).get();
+		return new TradeShipJob(ship, closestRoute);
+	}
+
 	/**
-	 * Sends a single ship on trade routes until terminated. This function will not return
-	 * TODO: Hook this up to a job queue so that we can handle more than a single trade ship
-	 * @param tradeShip The trade ship to manage
+	 * Performs the next step in a {@link TradeShipJob}
+	 * @param job the {@link TradeShipJob}
+	 * @return The updated {@link TradeShipJob}, with an updated nextAction time
 	 */
-	public void manageTradeShip(final Ship tradeShip) {
-		final String shipId = tradeShip.getSymbol();
+	public TradeShipJob manageTradeShip(final TradeShipJob job) {
 
-		while (true) {
-			final TradeRoute closestRoute = routeManager.getClosestRoute(tradeShip).get();
-			log.infof("Using Trade Route with Starting point %s and ending point %s",
-					closestRoute.getExportWaypoint().getSymbol(), closestRoute.getImportWaypoint().getSymbol());
-
-			final String firstWaypointSymbol = closestRoute.getExportWaypoint().getSymbol();
-			// If we're currently at the first waypoint, there's no need to navigate to it
-			if (!tradeShip.getNav().getWaypointSymbol().equals(firstWaypointSymbol)) {
-				final ShipNavigation newNav = orbitAndNavigate(shipId, firstWaypointSymbol);
-				tradeShip.setNav(newNav);
-			}
-
-			// Dock and purchase goods
-			throttler.throttle(() -> navigationClient.dock(shipId));
-
-			// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
-			// a ship is docked at them
-			try {
-				Thread.sleep(Duration.ofSeconds(5));
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-			}
-
-			// Force an update to we know the most up to date prices and trade limits
-			final MarketInfo exportMarketInfo = marketplaceManager.updateMarketInfo(closestRoute.getExportWaypoint());
-			final int totalCredits = accountManager.getCredits();
-			final List<TradeRequest> purchaseRequests = exportMarketInfo.buildPurchaseRequest(closestRoute.getGoods(),
-					tradeShip.getRemainingCargo(), totalCredits);
-
-			int total = 0;
-			for (final TradeRequest tradeRequest : purchaseRequests) {
-				final TradeResponse purchaseResponse = throttler
-						.throttle(() -> marketplaceRequester.purchase(shipId, tradeRequest));
-
-				total += purchaseResponse.getTransaction().getTotalPrice();
-				log.infof("Purchased %s unit(s) of %s for %s credits", tradeRequest.getUnits(),
-						tradeRequest.getSymbol(), purchaseResponse.getTransaction().getTotalPrice());
-			}
-			log.infof("Total Purchase Price: %s", total);
-
-			final ShipNavigation newNav = orbitAndNavigate(shipId, closestRoute.getImportWaypoint().getSymbol());
-			tradeShip.setNav(newNav);
-
-			// Dock and sell goods
-			throttler.throttle(() -> navigationClient.dock(shipId));
-
-			// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
-			// a ship is docked at them
-			try {
-				Thread.sleep(Duration.ofSeconds(5));
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-			}
-
-			// Force an update to we know the most up to date prices and trade limits
-			final MarketInfo importMarketInfo = marketplaceManager.updateMarketInfo(closestRoute.getImportWaypoint());
-
-			// Re-balance the sell requests because trade limits might be different
-			final List<TradeRequest> sellRequests = importMarketInfo.rebalanceTradeRequests(purchaseRequests);
-
-			int sellTotal = 0;
-			for (final TradeRequest tradeRequest : sellRequests) {
-				final TradeResponse purchaseResponse = throttler
-						.throttle(() -> marketplaceRequester.sell(shipId, tradeRequest));
-
-				sellTotal += purchaseResponse.getTransaction().getTotalPrice();
-				log.infof("Sold %s unit(s) of %s for %s credits", tradeRequest.getUnits(),
-						tradeRequest.getSymbol(), purchaseResponse.getTransaction().getTotalPrice());
-			}
-			log.infof("Total Sell Price: %s", sellTotal);
-
-			if (marketplaceManager.getMarketInfo(closestRoute.getImportWaypoint()).sellsProduct(Product.FUEL)) {
-				throttler.throttle(() -> marketplaceRequester.refuel(shipId));
-				log.infof("Refuled ship %s", shipId);
-			}
-			else {
-				log.warnf("Unable to refuel ship %s at waypoint %s", shipId,
-						closestRoute.getImportWaypoint().getSymbol());
-			}
-
-			return;
+		// The state of the job indicates what is was doing before it reached the manager
+		switch (job.getState()) {
+		case NOT_STARTED:
+			final Instant exportArrival = navigate(job.getShip(), job.getRoute().getExportWaypoint());
+			job.setNextAction(exportArrival);
+			job.setState(State.TRAVELING_TO_EXPORT);
+			break;
+		case TRAVELING_TO_EXPORT:
+			final List<TradeRequest> purchases = purchaseGoods(job);
+			job.setPurchases(purchases);
+			final Instant importArrival = navigate(job.getShip(), job.getRoute().getImportWaypoint());
+			job.setNextAction(importArrival);
+			job.setState(State.TRAVELING_TO_IMPORT);
+			break;
+		case TRAVELING_TO_IMPORT:
+			sellGoods(job);
+			// Make a whole new job and return it
+			return createJob(job.getShip());
 		}
 
+		return job;
+	}
+
+	private Instant navigate(final Ship ship, final Waypoint waypoint) {
+
+		final String waypointSymbol = waypoint.getSymbol();
+		// If we're currently at the first waypoint, there's no need to navigate to it
+		if (!ship.getNav().getWaypointSymbol().equals(waypointSymbol)) {
+			final ShipNavigation newNav = orbitAndNavigate(ship.getSymbol(), waypointSymbol);
+			ship.setNav(newNav);
+			return newNav.getRoute().getArrival();
+		}
+		// Navigation is done!
+		return Instant.now();
+	}
+
+	private List<TradeRequest> purchaseGoods(final TradeShipJob job) {
+		final Ship ship = job.getShip();
+		final TradeRoute route = job.getRoute();
+
+		// Dock and purchase goods
+		throttler.throttle(() -> navigationClient.dock(ship.getSymbol()));
+
+		// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
+		// a ship is docked at them
+		try {
+			Thread.sleep(Duration.ofSeconds(5));
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		// Force an update to we know the most up to date prices and trade limits
+		final MarketInfo exportMarketInfo = marketplaceManager.updateMarketInfo(route.getExportWaypoint());
+		final int totalCredits = accountManager.getCredits();
+		final List<TradeRequest> purchaseRequests = exportMarketInfo.buildPurchaseRequest(route.getGoods(),
+				ship.getRemainingCargo(), totalCredits);
+
+		int total = 0;
+		for (final TradeRequest tradeRequest : purchaseRequests) {
+			final TradeResponse purchaseResponse = throttler
+					.throttle(() -> marketplaceRequester.purchase(ship.getSymbol(), tradeRequest));
+
+			total += purchaseResponse.getTransaction().getTotalPrice();
+			log.infof("Purchased %s unit(s) of %s for %s credits", tradeRequest.getUnits(),
+					tradeRequest.getSymbol(), purchaseResponse.getTransaction().getTotalPrice());
+		}
+		log.infof("Total Purchase Price: %s", total);
+
+		return purchaseRequests;
+	}
+
+	private void sellGoods(final TradeShipJob job) {
+		final String shipId = job.getShip().getSymbol();
+		final TradeRoute route = job.getRoute();
+
+		// Dock and sell goods
+		throttler.throttle(() -> navigationClient.dock(shipId));
+
+		// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
+		// a ship is docked at them
+		try {
+			Thread.sleep(Duration.ofSeconds(5));
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		// Force an update to we know the most up to date prices and trade limits
+		final MarketInfo importMarketInfo = marketplaceManager.updateMarketInfo(job.getRoute().getImportWaypoint());
+
+		// Re-balance the sell requests because trade limits might be different
+		final List<TradeRequest> sellRequests = importMarketInfo.rebalanceTradeRequests(job.getPurchases());
+
+		int sellTotal = 0;
+		for (final TradeRequest tradeRequest : sellRequests) {
+			final TradeResponse purchaseResponse = throttler
+					.throttle(() -> marketplaceRequester.sell(shipId, tradeRequest));
+
+			sellTotal += purchaseResponse.getTransaction().getTotalPrice();
+			log.infof("Sold %s unit(s) of %s for %s credits", tradeRequest.getUnits(),
+					tradeRequest.getSymbol(), purchaseResponse.getTransaction().getTotalPrice());
+		}
+		log.infof("Total Sell Price: %s", sellTotal);
+
+		if (marketplaceManager.getMarketInfo(route.getImportWaypoint()).sellsProduct(Product.FUEL)) {
+			throttler.throttle(() -> marketplaceRequester.refuel(shipId));
+			log.infof("Refuled ship %s", shipId);
+		}
+		else {
+			log.warnf("Unable to refuel ship %s at waypoint %s", shipId,
+					route.getImportWaypoint().getSymbol());
+		}
 	}
 
 	private ShipNavigation orbitAndNavigate(final String shipId, final String waypointSymbol) {

--- a/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
@@ -1,0 +1,45 @@
+package org.psu.trademanager.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.psu.spacetraders.dto.Ship;
+import org.psu.spacetraders.dto.TradeRequest;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A job that can be performed by a trade ship
+ */
+@Getter
+@Setter
+@EqualsAndHashCode
+public class TradeShipJob {
+
+	private Ship ship;
+	private TradeRoute route;
+	/**
+	 * The purchases made on this trade route, only non-null once in the
+	 * TRAVELING_TO_IMPORT state and beyond
+	 */
+	private List<TradeRequest> purchases;
+	private Instant nextAction;
+	private State state;
+
+	public TradeShipJob(final Ship ship, final TradeRoute route) {
+		this.ship = ship;
+		this.route = route;
+		this.purchases = null;
+		this.nextAction = Instant.now();
+		this.state = State.NOT_STARTED;
+	}
+
+	public static enum State {
+		NOT_STARTED,
+		TRAVELING_TO_EXPORT,
+		TRAVELING_TO_IMPORT
+	}
+
+}

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -1,12 +1,17 @@
 package org.psu.trademanager;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +34,8 @@ import org.psu.spacetraders.dto.Transaction;
 import org.psu.spacetraders.dto.Waypoint;
 import org.psu.testutils.TestRequestThrottler;
 import org.psu.trademanager.dto.TradeRoute;
+import org.psu.trademanager.dto.TradeShipJob;
+import org.psu.trademanager.dto.TradeShipJob.State;
 
 
 /**
@@ -37,10 +44,29 @@ import org.psu.trademanager.dto.TradeRoute;
 public class TradeShipManagerTest {
 
 	/**
-	 * Tests {@link TradeShipManager#manageTradeShip}
+	 * Tests {@link TradeShipManager#createJob}
 	 */
 	@Test
-	public void manageTradeShip() {
+	public void createJob() {
+
+		final Ship ship = mock(Ship.class);
+		final RouteManager routeManager = mock(RouteManager.class);
+		final TradeRoute route = mock(TradeRoute.class);
+		when(routeManager.getClosestRoute(ship)).thenReturn(Optional.of(route));
+
+		final TradeShipManager manager = new TradeShipManager(null, null, null, null, null, routeManager);
+
+		final TradeShipJob job = manager.createJob(ship);
+
+		assertEquals(ship, job.getShip());
+		assertEquals(route, job.getRoute());
+	}
+
+	/**
+	 * Tests {@link TradeShipManager#manageTradeShip} with a job that hasn't yet been started
+	 */
+	@Test
+	public void manageTradeShipNotStarted() {
 
 		final RequestThrottler throttler = TestRequestThrottler.get();
 		final NavigationClient navClient = mock(NavigationClient.class);
@@ -51,50 +77,243 @@ public class TradeShipManagerTest {
 		final TradeShipManager manager = new TradeShipManager(throttler, navClient, accountManager, marketRequester,
 				marketManager, routeManager);
 
+		final NavigationResponse navResponse = mock(NavigationResponse.class);
+		final ShipNavigation shipNavResponse = mock(ShipNavigation.class);
+		final ShipRoute route = mock(ShipRoute.class);
+		final Instant arrivalTime = Instant.now().plus(Duration.ofMillis(10));
+		when(route.getArrival()).thenReturn(arrivalTime);
+		when(shipNavResponse.getRoute()).thenReturn(route);
+		when(navResponse.getNav()).thenReturn(shipNavResponse);
+		when(navClient.navigate(any(), any())).thenReturn(new DataWrapper<NavigationResponse>(navResponse, null));
+
 		final Ship ship = mock(Ship.class);
+		final ShipNavigation shipNav = mock(ShipNavigation.class);
+		when(shipNav.getWaypointSymbol()).thenReturn("Starting Symbol");
+		when(ship.getNav()).thenReturn(shipNav);
 
-		final String way1Symbol = "way1";
-		final Waypoint way1 = mock(Waypoint.class);
-		when(way1.getSymbol()).thenReturn(way1Symbol);
+		final Waypoint exportWaypoint = mock(Waypoint.class);
+		when(exportWaypoint.getSymbol()).thenReturn("export waypoint");
 		final TradeRoute tradeRoute = mock(TradeRoute.class);
-		when(tradeRoute.getExportWaypoint()).thenReturn(way1);
-		when(tradeRoute.getImportWaypoint()).thenReturn(way1);
-		when(tradeRoute.getGoods()).thenReturn(List.of(new Product("eggs")));
+		when(tradeRoute.getExportWaypoint()).thenReturn(exportWaypoint);
 
-		when(routeManager.getClosestRoute(ship)).thenReturn(Optional.of(tradeRoute));
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
 
-		final TradeRequest tradeRequest = mock(TradeRequest.class);
+		final TradeShipJob outputJob = manager.manageTradeShip(job);
 
-		final int credits = 5000;
-		when(accountManager.getCredits()).thenReturn(credits);
+		assertEquals(State.TRAVELING_TO_EXPORT, outputJob.getState());
+		assertEquals(arrivalTime, outputJob.getNextAction());
+		verify(ship).setNav(shipNavResponse);
+	}
 
-		final MarketInfo marketInfo = mock(MarketInfo.class);
-		when(marketInfo.sellsProduct(Product.FUEL)).thenReturn(true);
-		when(marketInfo.buildPurchaseRequest(any(), anyInt(), eq(credits))).thenReturn(List.of(tradeRequest));
-		when(marketInfo.rebalanceTradeRequests(eq(List.of(tradeRequest)))).thenReturn(List.of(tradeRequest));
+	/**
+	 * Tests {@link TradeShipManager#manageTradeShip} with a ship that is already at its export waypoint
+	 */
+	@Test
+	public void manageTradeShipStartingAtExport() {
 
-		when(marketManager.updateMarketInfo(way1)).thenReturn(marketInfo);
-		when(marketManager.getMarketInfo(way1)).thenReturn(marketInfo);
+		final RequestThrottler throttler = TestRequestThrottler.get();
+		final NavigationClient navClient = mock(NavigationClient.class);
+		final AccountManager accountManager = mock(AccountManager.class);
+		final MarketplaceRequester marketRequester = mock(MarketplaceRequester.class);
+		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
+		final RouteManager routeManager = mock(RouteManager.class);
+		final TradeShipManager manager = new TradeShipManager(throttler, navClient, accountManager, marketRequester,
+				marketManager, routeManager);
 
-		final ShipNavigation nav = mock(ShipNavigation.class);
-		when(nav.getWaypointSymbol()).thenReturn("some other waypoint");
-		when(ship.getNav()).thenReturn(nav);
+		final String waypointSymbol = "waypoint";
+		final Ship ship = mock(Ship.class);
+		final ShipNavigation shipNav = mock(ShipNavigation.class);
+		when(shipNav.getWaypointSymbol()).thenReturn(waypointSymbol);
+		when(ship.getNav()).thenReturn(shipNav);
+
+		final Waypoint exportWaypoint = mock(Waypoint.class);
+		when(exportWaypoint.getSymbol()).thenReturn(waypointSymbol);
+		final TradeRoute tradeRoute = mock(TradeRoute.class);
+		when(tradeRoute.getExportWaypoint()).thenReturn(exportWaypoint);
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
+
+		final TradeShipJob outputJob = manager.manageTradeShip(job);
+
+		assertEquals(State.TRAVELING_TO_EXPORT, outputJob.getState());
+		verifyNoInteractions(navClient);
+	}
+
+	/**
+	 * Tests {@link TradeShipManager#manageTradeShip} with a job where the ship was
+	 * traveling to the export waypoint
+	 */
+	@Test
+	public void manageTradeShipTravelingToExport() {
+
+		final RequestThrottler throttler = TestRequestThrottler.get();
+		final NavigationClient navClient = mock(NavigationClient.class);
+		final AccountManager accountManager = mock(AccountManager.class);
+		final MarketplaceRequester marketRequester = mock(MarketplaceRequester.class);
+		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
+		final RouteManager routeManager = mock(RouteManager.class);
+		final TradeShipManager manager = new TradeShipManager(throttler, navClient, accountManager, marketRequester,
+				marketManager, routeManager);
 
 		final NavigationResponse navResponse = mock(NavigationResponse.class);
 		final ShipNavigation shipNavResponse = mock(ShipNavigation.class);
 		final ShipRoute route = mock(ShipRoute.class);
-		when(route.getArrival()).thenReturn(Instant.now());
+		final Instant arrivalTime = Instant.now().plus(Duration.ofMillis(10));
+		when(route.getArrival()).thenReturn(arrivalTime);
 		when(shipNavResponse.getRoute()).thenReturn(route);
 		when(navResponse.getNav()).thenReturn(shipNavResponse);
 		when(navClient.navigate(any(), any())).thenReturn(new DataWrapper<NavigationResponse>(navResponse, null));
+
+		final Ship ship = mock(Ship.class);
+		final ShipNavigation shipNav = mock(ShipNavigation.class);
+		when(shipNav.getWaypointSymbol()).thenReturn("Starting Symbol");
+		when(ship.getNav()).thenReturn(shipNav);
+
+		final Waypoint exportWaypoint = mock(Waypoint.class);
+		final Waypoint importWaypoint = mock(Waypoint.class);
+		when(importWaypoint.getSymbol()).thenReturn("import waypoint");
+		final TradeRoute tradeRoute = mock(TradeRoute.class);
+		when(tradeRoute.getExportWaypoint()).thenReturn(exportWaypoint);
+		when(tradeRoute.getImportWaypoint()).thenReturn(importWaypoint);
+
+		final int credits = 5000;
+		when(accountManager.getCredits()).thenReturn(credits);
+
+		final TradeRequest tradeRequest = mock(TradeRequest.class);
+		final MarketInfo marketInfo = mock(MarketInfo.class);
+		when(marketInfo.buildPurchaseRequest(any(), anyInt(), eq(credits))).thenReturn(List.of(tradeRequest));
+
+		when(marketManager.updateMarketInfo(exportWaypoint)).thenReturn(marketInfo);
 
 		final Transaction transaction = mock(Transaction.class);
 		final TradeResponse tradeResponse = mock(TradeResponse.class);
 		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(marketRequester.purchase(any(), same(tradeRequest))).thenReturn(tradeResponse);
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
+		job.setState(State.TRAVELING_TO_EXPORT);
+
+		final TradeShipJob outputJob = manager.manageTradeShip(job);
+
+		assertEquals(State.TRAVELING_TO_IMPORT, outputJob.getState());
+		assertEquals(arrivalTime, outputJob.getNextAction());
+		verify(ship).setNav(shipNavResponse);
+		assertEquals(List.of(tradeRequest), job.getPurchases());
+	}
+
+	/**
+	 * Tests {@link TradeShipManager#manageTradeShip} with a job where the ship was
+	 * traveling to the import waypoint
+	 */
+	@Test
+	public void manageTradeShipTravelingToImport() {
+
+		final RequestThrottler throttler = TestRequestThrottler.get();
+		final NavigationClient navClient = mock(NavigationClient.class);
+		final AccountManager accountManager = mock(AccountManager.class);
+		final MarketplaceRequester marketRequester = mock(MarketplaceRequester.class);
+		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
+		final RouteManager routeManager = mock(RouteManager.class);
+		final TradeShipManager manager = new TradeShipManager(throttler, navClient, accountManager, marketRequester,
+				marketManager, routeManager);
+
+		final String shipId = "Ship";
+		final Ship ship = mock(Ship.class);
+		when(ship.getSymbol()).thenReturn(shipId);
+		final ShipNavigation shipNav = mock(ShipNavigation.class);
+		when(shipNav.getWaypointSymbol()).thenReturn("Starting Symbol");
+		when(ship.getNav()).thenReturn(shipNav);
+
+		final Waypoint importWaypoint = mock(Waypoint.class);
+		final TradeRoute tradeRoute = mock(TradeRoute.class);
+		when(tradeRoute.getImportWaypoint()).thenReturn(importWaypoint);
+
+		final int credits = 5000;
+		when(accountManager.getCredits()).thenReturn(credits);
+
+		final TradeRequest tradeRequest = mock(TradeRequest.class);
+		final MarketInfo marketInfo = mock(MarketInfo.class);
+		when(marketInfo.sellsProduct(Product.FUEL)).thenReturn(true);
+		when(marketInfo.rebalanceTradeRequests(eq(List.of(tradeRequest)))).thenReturn(List.of(tradeRequest));
+		when(marketManager.updateMarketInfo(importWaypoint)).thenReturn(marketInfo);
+		when(marketManager.getMarketInfo(importWaypoint)).thenReturn(marketInfo);
+
+		final Transaction transaction = mock(Transaction.class);
+		final TradeResponse tradeResponse = mock(TradeResponse.class);
+		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(marketRequester.sell(any(), same(tradeRequest))).thenReturn(tradeResponse);
 
-		manager.manageTradeShip(ship);
+		final TradeRoute newTradeRoute = mock(TradeRoute.class);
+		when(routeManager.getClosestRoute(ship)).thenReturn(Optional.of(newTradeRoute));
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
+		job.setState(State.TRAVELING_TO_IMPORT);
+		job.setPurchases(List.of(tradeRequest));
+
+		final TradeShipJob outputJob = manager.manageTradeShip(job);
+
+		assertEquals(State.NOT_STARTED, outputJob.getState());
+		assertEquals(ship, outputJob.getShip());
+		assertEquals(newTradeRoute, outputJob.getRoute());
+		verify(marketRequester).refuel(shipId);
+	}
+
+	/**
+	 * Tests {@link TradeShipManager#manageTradeShip} with a job where the ship was
+	 * traveling to the import waypoint but the import waypoint doesn't sell fuel
+	 */
+	@Test
+	public void manageTradeShipTravelingToImportNoFuel() {
+
+		final RequestThrottler throttler = TestRequestThrottler.get();
+		final NavigationClient navClient = mock(NavigationClient.class);
+		final AccountManager accountManager = mock(AccountManager.class);
+		final MarketplaceRequester marketRequester = mock(MarketplaceRequester.class);
+		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
+		final RouteManager routeManager = mock(RouteManager.class);
+		final TradeShipManager manager = new TradeShipManager(throttler, navClient, accountManager, marketRequester,
+				marketManager, routeManager);
+
+		final String shipId = "Ship";
+		final Ship ship = mock(Ship.class);
+		when(ship.getSymbol()).thenReturn(shipId);
+		final ShipNavigation shipNav = mock(ShipNavigation.class);
+		when(shipNav.getWaypointSymbol()).thenReturn("Starting Symbol");
+		when(ship.getNav()).thenReturn(shipNav);
+
+		final Waypoint importWaypoint = mock(Waypoint.class);
+		final TradeRoute tradeRoute = mock(TradeRoute.class);
+		when(tradeRoute.getImportWaypoint()).thenReturn(importWaypoint);
+
+		final int credits = 5000;
+		when(accountManager.getCredits()).thenReturn(credits);
+
+		final TradeRequest tradeRequest = mock(TradeRequest.class);
+		final MarketInfo marketInfo = mock(MarketInfo.class);
+		// No Fuel!
+		when(marketInfo.sellsProduct(Product.FUEL)).thenReturn(false);
+		when(marketInfo.rebalanceTradeRequests(eq(List.of(tradeRequest)))).thenReturn(List.of(tradeRequest));
+		when(marketManager.updateMarketInfo(importWaypoint)).thenReturn(marketInfo);
+		when(marketManager.getMarketInfo(importWaypoint)).thenReturn(marketInfo);
+
+		final Transaction transaction = mock(Transaction.class);
+		final TradeResponse tradeResponse = mock(TradeResponse.class);
+		when(tradeResponse.getTransaction()).thenReturn(transaction);
+		when(marketRequester.sell(any(), same(tradeRequest))).thenReturn(tradeResponse);
+
+		final TradeRoute newTradeRoute = mock(TradeRoute.class);
+		when(routeManager.getClosestRoute(ship)).thenReturn(Optional.of(newTradeRoute));
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
+		job.setState(State.TRAVELING_TO_IMPORT);
+		job.setPurchases(List.of(tradeRequest));
+
+		final TradeShipJob outputJob = manager.manageTradeShip(job);
+
+		assertEquals(State.NOT_STARTED, outputJob.getState());
+		assertEquals(ship, outputJob.getShip());
+		assertEquals(newTradeRoute, outputJob.getRoute());
+		verify(marketRequester, times(0)).refuel(shipId);
 	}
 
 }


### PR DESCRIPTION
Breaks apart the Trade Manager so that it no longer performs the entire trade route in one blocking method call. Rather it is called with a TradeShipJob, performs one step, and returns the next TradeShipJob.