### PR TITLE
Reduce Purchases on Unknown Routes

### DIFF
--- a/java/src/main/java/org/psu/spacetraders/api/MarketplaceRequester.java
+++ b/java/src/main/java/org/psu/spacetraders/api/MarketplaceRequester.java
@@ -94,8 +94,9 @@ public class MarketplaceRequester {
 	 * @param waypoint    The waypoint at which to sell the goods, assumes the ship
 	 *                    has finished traveling to it
 	 * @param itemsToSell The items to sell, they must be in the ship's cargo bay
+	 * @return The profit from selling items (amount gained from selling minus cost of refueling)
 	 */
-	public void dockAndSellItems(final Ship ship, final Waypoint waypoint, final List<CargoItem> itemsToSell) {
+	public Integer dockAndSellItems(final Ship ship, final Waypoint waypoint, final List<CargoItem> itemsToSell) {
 		final String shipId = ship.getSymbol();
 
 		navHelper.dock(ship);
@@ -120,12 +121,14 @@ public class MarketplaceRequester {
 		log.infof("Sold goods from ship %s for a total of %s credits", shipId, totalCredits);
 
 		if (market.sellsProduct(Product.FUEL)) {
-			refuel(ship);
+			final RefuelResponse refuelResponse = refuel(ship);
+			totalCredits -= refuelResponse.getTransaction().getTotalPrice();
 			log.infof("Refueled ship %s", shipId);
 		}
 		else {
 			log.warnf("Unable to refuel ship %s at current waypoint", shipId);
 		}
+		return totalCredits;
 	}
 
 }

--- a/java/src/main/java/org/psu/spacetraders/dto/MarketInfo.java
+++ b/java/src/main/java/org/psu/spacetraders/dto/MarketInfo.java
@@ -41,10 +41,12 @@ public class MarketInfo {
 	 * @param capacity      The total number of items to buy
 	 * @param totalCredits  the number of credits the user has, should not spend
 	 *                      more than half of their total
+	 * @param knownRoute    If the route is known, if not, just buy one of every
+	 *                      item
 	 * @return The {@link TradeRequest}s
 	 */
 	public List<TradeRequest> buildPurchaseRequest(final List<Product> productsToBuy, final int capacity,
-			final int totalCredits) {
+			final int totalCredits, final boolean knownRoute) {
 		final Set<String> productSymbolsToBuy = productsToBuy.stream().map(Product::getSymbol)
 				.collect(Collectors.toSet());
 		final List<TradeGood> sortedTradeGoods = this.tradeGoods.stream()
@@ -58,7 +60,8 @@ public class MarketInfo {
 
 		for (final TradeGood tradeGood : sortedTradeGoods) {
 			// Find how many items we can hold (in the ship or in the request)
-			final int requestCapacity = Math.min(remainingItemsToBuy, tradeGood.getTradeVolume());
+			// If the route is not known, just try to buy one item
+			final int requestCapacity = knownRoute ? Math.min(remainingItemsToBuy, tradeGood.getTradeVolume()) : 1;
 			// Limit the quantity to buy if it would be too expensive
 			final int quantityToBuy = Math.min(requestCapacity, remainingBudget / tradeGood.getPurchasePrice());
 			output.add(new TradeRequest(tradeGood.getSymbol(), quantityToBuy));

--- a/java/src/main/java/org/psu/trademanager/RouteManager.java
+++ b/java/src/main/java/org/psu/trademanager/RouteManager.java
@@ -99,7 +99,9 @@ public class RouteManager {
 		if (mostProfitableRoute.isEmpty()) {
 			// All routes are unknown, go with shortest route
 			log.info("Found no routes with known profits, picking shortest route");
-			return shortestUnknownRoute.get();
+			final TradeRoute shortestRoute = shortestUnknownRoute.get();
+			shortestRoute.setKnown(false);
+			return shortestRoute;
 		}
 		if (shortestUnknownRoute.isEmpty()) {
 			// All routes are known, go with the most profitable route
@@ -108,6 +110,7 @@ public class RouteManager {
 			log.infof("All routes have known profits, picking the route with potential profit of %s per %s",
 					routeProfit.profit(), routeProfit.itemToSell());
 			chosenRoute.setGoods(List.of(routeProfit.itemToSell()));
+			chosenRoute.setKnown(true);
 			return chosenRoute;
 		}
 		// For now, randomly pick the shortest or most profitable, balancing exploring and making money
@@ -117,10 +120,13 @@ public class RouteManager {
 			log.infof("Picking most profitable route, with potential profit of %s per %s",
 					routeProfit.profit(), routeProfit.itemToSell());
 			chosenRoute.setGoods(List.of(routeProfit.itemToSell()));
+			chosenRoute.setKnown(true);
 			return chosenRoute;
 		}
 		log.info("Picking shortest route");
-		return shortestUnknownRoute.get();
+		final TradeRoute shortestRoute = shortestUnknownRoute.get();
+		shortestRoute.setKnown(false);
+		return shortestRoute;
 	}
 
 	private RouteProfit getPotentialProfit(final TradeRoute route) {

--- a/java/src/main/java/org/psu/trademanager/TradeShipManager.java
+++ b/java/src/main/java/org/psu/trademanager/TradeShipManager.java
@@ -139,7 +139,7 @@ public class TradeShipManager {
 		final MarketInfo exportMarketInfo = marketplaceManager.updateMarketInfo(route.getExportWaypoint());
 		final int totalCredits = accountManager.getCredits();
 		final List<TradeRequest> purchaseRequests = exportMarketInfo.buildPurchaseRequest(route.getGoods(),
-				ship.getRemainingCargo(), totalCredits);
+				ship.getRemainingCargo(), totalCredits, route.isKnown());
 
 		int total = 0;
 		for (final TradeRequest tradeRequest : purchaseRequests) {
@@ -150,6 +150,7 @@ public class TradeShipManager {
 					tradeRequest.getSymbol(), purchaseResponse.getTransaction().getTotalPrice());
 		}
 		log.infof("Total Purchase Price: %s", total);
+		route.setPurchasePrice(total);
 
 		return purchaseRequests;
 	}
@@ -162,7 +163,11 @@ public class TradeShipManager {
 		final List<CargoItem> cargoToSell = ship.getCargo().inventory().stream()
 				.filter(c -> productsToSell.contains(c.symbol())).toList();
 
-		marketplaceRequester.dockAndSellItems(ship, route.getImportWaypoint(), cargoToSell);
+		final Integer sellPrice = marketplaceRequester.dockAndSellItems(ship, route.getImportWaypoint(), cargoToSell);
+		if (route.getPurchasePrice() != null) {
+			log.infof("Trade route for ship %s made a total profit of %s", ship.getSymbol(),
+					sellPrice - route.getPurchasePrice());
+		}
 	}
 
 }

--- a/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
@@ -20,6 +20,24 @@ public class TradeRoute {
 	private final Waypoint exportWaypoint;
 	private final Waypoint importWaypoint;
 	private List<Product> goods;
+	/**
+	 * This will only be populated after purchasing items at the export waypoint,
+	 * and will never be populated for a route which starts in the middle
+	 */
+	private Integer purchasePrice;
+	/**
+	 * An unknown trade route is one where the prices are not known at either the
+	 * export or the import, or both
+	 */
+	private boolean isKnown;
+
+	public TradeRoute(final Waypoint exportWaypoint, final Waypoint importWaypoint, final List<Product> goods) {
+		this.exportWaypoint = exportWaypoint;
+		this.importWaypoint = importWaypoint;
+		this.goods = goods;
+		this.purchasePrice = null;
+		this.isKnown = false;
+	}
 
 	/**
 	 * Determines if a ship can perform the trade route (on a single tank of fuel)

--- a/java/src/test/java/org/psu/spacetraders/api/MarketplaceRequesterTest.java
+++ b/java/src/test/java/org/psu/spacetraders/api/MarketplaceRequesterTest.java
@@ -148,22 +148,28 @@ public class MarketplaceRequesterTest {
 		final Waypoint waypoint = mock(Waypoint.class);
 		when(marketplaceManager.updateMarketInfo(waypoint)).thenReturn(marketInfo);
 
+		final int sellPrice = 500;
 		final Transaction transaction = mock(Transaction.class);
-		when(transaction.getTotalPrice()).thenReturn(100);
+		when(transaction.getTotalPrice()).thenReturn(sellPrice);
 		final TradeResponse tradeResponse = mock(TradeResponse.class);
 		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(client.sell(shipId, tradeRequest)).thenReturn(new DataWrapper<TradeResponse>(tradeResponse, null));
 
 		when(marketInfo.sellsProduct(Product.FUEL)).thenReturn(true);
 
+		final int refuelPrice = 100;
+		final Transaction refuelTransaction = mock(Transaction.class);
+		when(refuelTransaction.getTotalPrice()).thenReturn(refuelPrice);
 		final RefuelResponse response = mock(RefuelResponse.class);
+		when(response.getTransaction()).thenReturn(refuelTransaction);
 		when(client.refuel(shipId)).thenReturn(new DataWrapper<RefuelResponse>(response, null));
 
-		requester.dockAndSellItems(ship, waypoint, cargoItems);
+		final int profit = requester.dockAndSellItems(ship, waypoint, cargoItems);
 
 		verify(navHelper).dock(ship);
 		verify(client).sell(shipId, tradeRequest);
 		verify(client).refuel(shipId);
+		assertEquals(sellPrice - refuelPrice, profit);
 	}
 
 	/**
@@ -192,8 +198,9 @@ public class MarketplaceRequesterTest {
 		final Waypoint waypoint = mock(Waypoint.class);
 		when(marketplaceManager.updateMarketInfo(waypoint)).thenReturn(marketInfo);
 
+		final int sellPrice = 100;
 		final Transaction transaction = mock(Transaction.class);
-		when(transaction.getTotalPrice()).thenReturn(100);
+		when(transaction.getTotalPrice()).thenReturn(sellPrice);
 		final TradeResponse tradeResponse = mock(TradeResponse.class);
 		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(client.sell(shipId, tradeRequest)).thenReturn(new DataWrapper<TradeResponse>(tradeResponse, null));
@@ -201,11 +208,12 @@ public class MarketplaceRequesterTest {
 		// Doesn't sell fuel
 		when(marketInfo.sellsProduct(Product.FUEL)).thenReturn(false);
 
-		requester.dockAndSellItems(ship, waypoint, cargoItems);
+		final int profit = requester.dockAndSellItems(ship, waypoint, cargoItems);
 
 		verify(navHelper).dock(ship);
 		verify(client).sell(shipId, tradeRequest);
 		verify(client, times(0)).refuel(shipId);
+		assertEquals(profit, sellPrice);
 	}
 
 }

--- a/java/src/test/java/org/psu/spacetraders/dto/MarketInfoTest.java
+++ b/java/src/test/java/org/psu/spacetraders/dto/MarketInfoTest.java
@@ -136,7 +136,7 @@ public class MarketInfoTest {
 		// and 0 units of product1
 
 		final List<TradeRequest> tradeRequests = marketInfo.buildPurchaseRequest(
-				List.of(product1, product2, product4), 4, 10000);
+				List.of(product1, product2, product4), 4, 10000, true);
 
 		assertEquals(2, tradeRequests.size());
 
@@ -184,7 +184,7 @@ public class MarketInfoTest {
 		// We can buy 5 tradeGood2's, spending 500 additional credits
 
 		final List<TradeRequest> tradeRequests = marketInfo.buildPurchaseRequest(
-				List.of(product1, product2, product3), 100, 3000);
+				List.of(product1, product2, product3), 100, 3000, true);
 
 		assertEquals(2, tradeRequests.size());
 
@@ -193,6 +193,58 @@ public class MarketInfoTest {
 
 		assertEquals(5, requestsByProductSymbol.get(productSymbol1).getUnits());
 		assertEquals(5, requestsByProductSymbol.get(productSymbol2).getUnits());
+	}
+
+	/**
+	 * Tests {@link MarketInfo#buildPurchaseRequest} with an unknown route
+	 */
+	@Test
+	public void buildPurchaseRequestUnknownRoute() {
+
+		final String productSymbol1 = "milk";
+		final String productSymbol2 = "eggs";
+		final String productSymbol3 = "cheese";
+		final String productSymbol4 = "bread";
+
+		final Product product1 = new Product(productSymbol1);
+		final Product product2 = new Product(productSymbol2);
+		final Product product4 = new Product(productSymbol4);
+
+		final TradeGood tradeGood1 = new TradeGood();
+		tradeGood1.setPurchasePrice(100);
+		tradeGood1.setSymbol(productSymbol1);
+		tradeGood1.setTradeVolume(10);
+
+		final TradeGood tradeGood2 = new TradeGood();
+		tradeGood2.setPurchasePrice(200);
+		tradeGood2.setSymbol(productSymbol2);
+		tradeGood2.setTradeVolume(5);
+
+		final TradeGood tradeGood3 = new TradeGood();
+		tradeGood3.setPurchasePrice(50);
+		tradeGood3.setSymbol(productSymbol3);
+		tradeGood3.setTradeVolume(15);
+
+		final TradeGood tradeGood4 = new TradeGood();
+		tradeGood4.setPurchasePrice(500);
+		tradeGood4.setSymbol(productSymbol4);
+		tradeGood4.setTradeVolume(1);
+
+		final MarketInfo marketInfo = new MarketInfo(null, null, null,
+				List.of(tradeGood1, tradeGood2, tradeGood3, tradeGood4));
+
+		// We want to buy one of each item because the route is unknown, but have a capacity of 3
+		final List<TradeRequest> tradeRequests = marketInfo.buildPurchaseRequest(
+				List.of(product1, product2, product4), 3, 10000, false);
+
+		assertEquals(3, tradeRequests.size());
+
+		final Map<String, TradeRequest> requestsByProductSymbol = tradeRequests.stream()
+				.collect(Collectors.toMap(TradeRequest::getSymbol, Function.identity()));
+
+		assertEquals(1, requestsByProductSymbol.get(productSymbol4).getUnits());
+		assertEquals(1, requestsByProductSymbol.get(productSymbol2).getUnits());
+		assertEquals(1, requestsByProductSymbol.get(productSymbol1).getUnits());
 	}
 
 	/**

--- a/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
+++ b/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
@@ -2,6 +2,7 @@ package org.psu.spacetraders.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,24 @@ import org.psu.trademanager.dto.TradeRoute;
  * Tests for {@link TradeRoute}
  */
 public class TradeRouteTest {
+
+	/**
+	 * Tests the constructor
+	 */
+	@Test
+	public void constructor() {
+		final Waypoint importWaypoint = mock(Waypoint.class);
+		final Waypoint exportWaypoint = mock(Waypoint.class);
+		final List<Product> goods = List.of(mock(Product.class), mock(Product.class));
+
+		final TradeRoute route = new TradeRoute(exportWaypoint, importWaypoint, goods);
+
+		assertEquals(importWaypoint, route.getImportWaypoint());
+		assertEquals(exportWaypoint, route.getExportWaypoint());
+		assertEquals(goods, route.getGoods());
+		assertFalse(route.isKnown());
+		assertNull(route.getPurchasePrice());
+	}
 
 	/**
 	 * Tests {@link TradeRoute#isPossible} when the ship is too far from the starting waypoint

--- a/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
@@ -1,6 +1,7 @@
 package org.psu.trademanager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -150,6 +151,7 @@ public class RouteManagerTest {
 		assertEquals(way2, bestRoute.getExportWaypoint());
 		assertEquals(way3, bestRoute.getImportWaypoint());
 		assertEquals(List.of(prod2), bestRoute.getGoods());
+		assertFalse(bestRoute.isKnown());
 	}
 
 	/**
@@ -220,6 +222,7 @@ public class RouteManagerTest {
 		assertEquals(way1, bestRoute.getExportWaypoint());
 		assertEquals(way3, bestRoute.getImportWaypoint());
 		assertEquals(List.of(prod1), bestRoute.getGoods());
+		assertTrue(bestRoute.isKnown());
 	}
 
 	/**
@@ -297,6 +300,7 @@ public class RouteManagerTest {
 		assertEquals(way1, bestRoute.getExportWaypoint());
 		assertEquals(way3, bestRoute.getImportWaypoint());
 		assertEquals(List.of(prod1), bestRoute.getGoods());
+		assertTrue(bestRoute.isKnown());
 
 		// Now, return a large double, this means we will go with the shortest route
 		when(randomProvider.nextDouble()).thenReturn(1.0);
@@ -306,6 +310,7 @@ public class RouteManagerTest {
 		assertEquals(way2, nextBestRoute.getExportWaypoint());
 		assertEquals(way3, nextBestRoute.getImportWaypoint());
 		assertEquals(List.of(prod1, prod2), nextBestRoute.getGoods());
+		assertFalse(nextBestRoute.isKnown());
 	}
 
 }

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -171,6 +171,7 @@ public class TradeShipManagerTest {
 		final TradeRoute tradeRoute = mock(TradeRoute.class);
 		when(tradeRoute.getExportWaypoint()).thenReturn(exportWaypoint);
 		when(tradeRoute.getImportWaypoint()).thenReturn(importWaypoint);
+		when(tradeRoute.isKnown()).thenReturn(false);
 
 		final Instant arrivalTime = Instant.now().plus(Duration.ofMillis(10));
 		when(navHelper.navigate(ship, importWaypoint)).thenReturn(arrivalTime);
@@ -180,7 +181,8 @@ public class TradeShipManagerTest {
 
 		final TradeRequest tradeRequest = mock(TradeRequest.class);
 		final MarketInfo marketInfo = mock(MarketInfo.class);
-		when(marketInfo.buildPurchaseRequest(any(), anyInt(), eq(credits))).thenReturn(List.of(tradeRequest));
+		when(marketInfo.buildPurchaseRequest(any(), anyInt(), eq(credits), eq(false)))
+				.thenReturn(List.of(tradeRequest));
 
 		when(marketManager.updateMarketInfo(exportWaypoint)).thenReturn(marketInfo);
 
@@ -231,6 +233,8 @@ public class TradeShipManagerTest {
 
 		final TradeShipJob job = new TradeShipJob(ship, tradeRoute);
 		job.setState(State.TRAVELING_TO_IMPORT);
+
+		when(marketRequester.dockAndSellItems(ship, importWaypoint, List.of(cargoItem))).thenReturn(10);
 
 		final TradeShipJob outputJob = manager.manageTradeShip(job);
 


### PR DESCRIPTION
When a route is unknown, only purchase one of every item because we could be losing money. Continue normal purchasing practices on known routes.
Also record a route's profit for easier log reading.