### PR TITLE
Refactor Cooldown

### DIFF
--- a/java/src/main/java/org/psu/miningmanager/dto/Cooldown.java
+++ b/java/src/main/java/org/psu/miningmanager/dto/Cooldown.java
@@ -1,7 +1,5 @@
 package org.psu.miningmanager.dto;
 
-import java.time.Instant;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.AllArgsConstructor;
@@ -14,6 +12,6 @@ import lombok.RequiredArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Cooldown {
 
-	private Instant expiration;
+	private int totalSeconds;
 
 }

--- a/java/src/main/java/org/psu/trademanager/TradeShipManager.java
+++ b/java/src/main/java/org/psu/trademanager/TradeShipManager.java
@@ -41,7 +41,7 @@ public class TradeShipManager {
 	private RouteManager routeManager;
 
 	@Inject
-	public TradeShipManager(@ConfigProperty(name = "app.navigation-pad-ms") final int navigationPad,
+	public TradeShipManager(@ConfigProperty(name = "app.cooldown-pad-ms") final int navigationPad,
 			final NavigationHelper navigationHelper,
 			final AccountManager accountManager, final MarketplaceRequester marketplaceRequester,
 			final MarketplaceManager marketplaceManager, final RouteManager routeManager) {

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 app.max-items-per-page=20
-app.navigation-pad-ms=3000
 app.cooldown-pad-ms=3000
 
 app.throttler.rate-limiters[0].requests=2


### PR DESCRIPTION
When possible, use data from the API response to produce the time needed to wait. This will reduce the impact of differences between local time and Space Traders server time.