### PR TITLE
Multi-Stop Routes in Trade Manager

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     
     // Third-Party
     implementation 'com.google.guava:guava'
+    implementation 'org.jgrapht:jgrapht-core:1.5.2'
 
     compileOnly 'org.projectlombok:lombok:1.18.34'
 	annotationProcessor 'org.projectlombok:lombok:1.18.34'

--- a/java/src/main/java/org/psu/navigation/NavigationPath.java
+++ b/java/src/main/java/org/psu/navigation/NavigationPath.java
@@ -1,0 +1,26 @@
+package org.psu.navigation;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.psu.spacetraders.dto.Waypoint;
+
+import lombok.Data;
+
+/**
+ * A path for ship navigation
+ */
+@Data
+public class NavigationPath {
+
+	private final double length;
+	private final List<Waypoint> waypoints;
+
+	public static NavigationPath combine(final NavigationPath path1, final NavigationPath path2) {
+		final double totalLength = path1.getLength() + path2.getLength();
+		final List<Waypoint> allWaypoints = Stream.concat(path1.getWaypoints().stream(), path2.getWaypoints().stream())
+				.toList();
+		return new NavigationPath(totalLength, allWaypoints);
+	}
+
+}

--- a/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
+++ b/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
@@ -1,0 +1,134 @@
+package org.psu.navigation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.psu.spacetraders.dto.Ship;
+import org.psu.spacetraders.dto.ShipRoute.RoutePoint;
+import org.psu.spacetraders.dto.Waypoint;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.jbosslog.JBossLog;
+
+/**
+ * Determines the shortest path between two waypoints, may require stops at points to refuel
+ */
+@JBossLog
+@ApplicationScoped
+public class RefuelPathCalculator {
+
+	private SimpleWeightedGraph<Waypoint, DefaultWeightedEdge> refuelGraph;
+
+	@Inject
+	public RefuelPathCalculator() {
+		this.refuelGraph = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+	}
+
+	public void loadRefuelWaypoints(final List<Waypoint> refuelWaypoints) {
+		// Reset the refuel graph
+		this.refuelGraph = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+
+		refuelWaypoints.forEach(w -> this.refuelGraph.addVertex(w));
+
+		// Add weighted edges
+		for (final Waypoint way1 : refuelWaypoints) {
+			for (final Waypoint way2 : refuelWaypoints) {
+				if (way1 != way2) {
+					final DefaultWeightedEdge newEdge = this.refuelGraph.addEdge(way1, way2);
+					if (newEdge != null) {
+						// Non-null indicates that this is a new edge
+						this.refuelGraph.setEdgeWeight(newEdge, way1.distTo(way2));
+					}
+				}
+			}
+		}
+
+		log.info("Loaded Graph");
+	}
+
+	/**
+	 * @param ship the ship
+	 * @param destination the ship's desired destination
+	 * @return A path object containing the total distance to travel and a list of
+	 *         waypoints containing the optimal path from the origin to the
+	 *         destination, this list will not include the origin. Will return null
+	 *         if there is no feasible path to the destination.
+	 */
+	public NavigationPath determineShortestRoute(final Ship ship, final Waypoint destination) {
+		final Waypoint fakeOrigin = new Waypoint();
+		final RoutePoint shipPosition = ship.getNav().getRoute().getDestination();
+		fakeOrigin.setX(shipPosition.getX());
+		fakeOrigin.setY(shipPosition.getY());
+
+		return determineShortestRoute(fakeOrigin, destination, ship.getFuel().current(), ship.getFuel().capacity());
+	}
+
+	/**
+	 * @param origin       the current ship location
+	 * @param destination  the waypoint the ship intends to reach
+	 * @param currentFuel  the amount of fuel the ship has currently
+	 * @param fuelCapacity the total fuel capacity of the ship
+	 * @return A path object containing the total distance to travel and a list of
+	 *         waypoints containing the optimal path from the origin to the
+	 *         destination, this list will not include the origin. Will return null
+	 *         if there is no feasible path to the destination.
+	 */
+	public NavigationPath determineShortestRoute(final Waypoint origin, final Waypoint destination,
+			final int currentFuel, final int fuelCapacity) {
+
+		@SuppressWarnings("unchecked")
+		final SimpleWeightedGraph<Waypoint, DefaultWeightedEdge> tempGraph =
+				(SimpleWeightedGraph<Waypoint, DefaultWeightedEdge>) this.refuelGraph.clone();
+		if (!tempGraph.containsVertex(origin)) {
+			addVertex(tempGraph, origin);
+		}
+		if (!tempGraph.containsVertex(destination)) {
+			addVertex(tempGraph, destination);
+		}
+
+		final List<DefaultWeightedEdge> edgesToRemove = new ArrayList<>();
+		for (final DefaultWeightedEdge edge : tempGraph.edgeSet()) {
+			final double edgeWeight = tempGraph.getEdgeWeight(edge);
+			final boolean containsOrigin = origin.equals(tempGraph.getEdgeSource(edge))
+					|| origin.equals(tempGraph.getEdgeTarget(edge));
+			// Remove the edges that the ship cannot traverse from its current location given its current fuel
+			// Remove the edges that the ship cannot traverse with its max fuel
+			if ((containsOrigin && edgeWeight > currentFuel) || (edgeWeight > fuelCapacity)) {
+				edgesToRemove.add(edge);
+			}
+		}
+		tempGraph.removeAllEdges(edgesToRemove);
+
+		final DijkstraShortestPath<Waypoint, DefaultWeightedEdge> dijk = new DijkstraShortestPath<>(tempGraph);
+		final GraphPath<Waypoint, DefaultWeightedEdge> shortestPath = dijk.getPath(origin, destination);
+
+		if (shortestPath == null) {
+			return null;
+		}
+
+		final List<Waypoint> waypointList = shortestPath.getVertexList();
+		final double totalLength = shortestPath.getWeight();
+
+		// Be sure to strip out the origin
+		return new NavigationPath(totalLength, waypointList.subList(1, waypointList.size()));
+
+	}
+
+	private void addVertex(final SimpleWeightedGraph<Waypoint, DefaultWeightedEdge> graph, final Waypoint waypoint) {
+		graph.addVertex(waypoint);
+		for (final Waypoint way : graph.vertexSet()) {
+			if (way != waypoint) {
+				final DefaultWeightedEdge newEdge = graph.addEdge(waypoint, way);
+				if (newEdge != null) {
+					graph.setEdgeWeight(newEdge, waypoint.distTo(way));
+				}
+			}
+		}
+	}
+
+}

--- a/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
@@ -1,6 +1,7 @@
 package org.psu.trademanager.dto;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.psu.spacetraders.dto.Product;
 import org.psu.spacetraders.dto.Ship;
@@ -56,5 +57,23 @@ public class TradeRoute {
 		return Math.sqrt(Math.pow(this.exportWaypoint.getX() - this.importWaypoint.getX(), 2) +
 				Math.pow(this.exportWaypoint.getY() - this.importWaypoint.getY(), 2));
 	}
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+			return true;
+		}
+        if (other == null || getClass() != other.getClass()) {
+			return false;
+		}
+        TradeRoute otherRoute = (TradeRoute) other;
+        return Objects.equals(this.exportWaypoint, otherRoute.getExportWaypoint()) &&
+               Objects.equals(this.importWaypoint, otherRoute.getImportWaypoint());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.exportWaypoint, this.importWaypoint);
+    }
 
 }

--- a/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
@@ -1,9 +1,11 @@
 package org.psu.trademanager.dto;
 
 import java.time.Instant;
+import java.util.List;
 
 import org.psu.shiporchestrator.ShipJob;
 import org.psu.spacetraders.dto.Ship;
+import org.psu.spacetraders.dto.Waypoint;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,20 +21,24 @@ public class TradeShipJob implements ShipJob {
 
 	private Ship ship;
 	private TradeRoute route;
+	/**
+	 * The path to take for this trade route. Can be null if the route is being started in the middle
+	 */
+	private List<Waypoint> waypoints;
 	private Instant nextAction;
 	private State state;
 
-	public TradeShipJob(final Ship ship, final TradeRoute route) {
+	public TradeShipJob(final Ship ship, final TradeRoute route, final List<Waypoint> waypoints) {
 		this.ship = ship;
 		this.route = route;
+		this.waypoints = waypoints;
 		this.nextAction = Instant.now();
 		this.state = State.NOT_STARTED;
 	}
 
 	public static enum State {
 		NOT_STARTED,
-		TRAVELING_TO_EXPORT,
-		TRAVELING_TO_IMPORT
+		TRAVELING
 	}
 
 }

--- a/java/src/test/java/org/psu/navigation/NavigationPathTest.java
+++ b/java/src/test/java/org/psu/navigation/NavigationPathTest.java
@@ -1,0 +1,37 @@
+package org.psu.navigation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.psu.spacetraders.dto.Waypoint;
+
+/**
+ * Tests for {@link NavigationPath}
+ */
+public class NavigationPathTest {
+
+	/**
+	 * Tests the combine method
+	 */
+	@Test
+	public void combine() {
+
+		final double len1 = 5.67;
+		final Waypoint way1 = mock();
+		final Waypoint way2 = mock();
+		final NavigationPath path1 = new NavigationPath(len1, List.of(way1, way2));
+
+		final double len2 = 1.23;
+		final Waypoint way3 = mock();
+		final NavigationPath path2 = new NavigationPath(len2, List.of(way3));
+
+		final NavigationPath combinedPath = NavigationPath.combine(path1, path2);
+
+		assertEquals(len1 + len2, combinedPath.getLength(), 1e-9);
+		assertEquals(List.of(way1, way2, way3), combinedPath.getWaypoints());
+	}
+
+}

--- a/java/src/test/java/org/psu/navigation/RefuelPathCalculatorTest.java
+++ b/java/src/test/java/org/psu/navigation/RefuelPathCalculatorTest.java
@@ -1,0 +1,207 @@
+package org.psu.navigation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.psu.spacetraders.dto.FuelStatus;
+import org.psu.spacetraders.dto.Ship;
+import org.psu.spacetraders.dto.ShipRoute.RoutePoint;
+import org.psu.spacetraders.dto.Waypoint;
+
+/**
+ * Tests for {@link RefuelPathCalculator}
+ */
+public class RefuelPathCalculatorTest {
+
+	/**
+	 * Tests the case where the origin and the destination are both in the original map
+	 */
+	@Test
+	public void originAndDestinationInMap() {
+
+		final Waypoint origin = makeWaypoint(0, 0);
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		final Waypoint way3 = makeWaypoint(100, 0);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		final Waypoint destination = makeWaypoint(200, 0);
+
+		// Quickest route is through way3
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(origin, way1, way2, way3, way4, way5, destination));
+
+		// Enough fuel to go from origin to any of the intermediate waypoints, but not
+		// right to the destination
+		final NavigationPath path = calculator.determineShortestRoute(origin, destination, 150, 150);
+
+		assertEquals(200, path.getLength(), 1e-9);
+		assertEquals(List.of(way3, destination), path.getWaypoints());
+	}
+
+	/**
+	 * Tests the case where the origin and the destination are not in the original map
+	 */
+	@Test
+	public void originAndDestinationNotInMap() {
+
+		final Waypoint origin = makeWaypoint(0, 0);
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		final Waypoint way3 = makeWaypoint(100, 0);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		final Waypoint destination = makeWaypoint(200, 0);
+
+		// Quickest route is through way3
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(way1, way2, way3, way4, way5));
+
+		// Enough fuel to go from origin to any of the intermediate waypoints, but not
+		// right to the destination
+		final NavigationPath path = calculator.determineShortestRoute(origin, destination, 150, 150);
+
+		assertEquals(200, path.getLength(), 1e-9);
+		assertEquals(List.of(way3, destination), path.getWaypoints());
+	}
+
+	/**
+	 * Tests the case where the origin and the destination are not in the original
+	 * map using the method which takes a ship
+	 */
+	@Test
+	public void originAndDestinationNotInMapShip() {
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		final Waypoint way3 = makeWaypoint(100, 0);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		final Waypoint destination = makeWaypoint(200, 0);
+
+		// Quickest route is through way3
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(way1, way2, way3, way4, way5));
+
+		final Ship ship = mock(Ship.class, Answers.RETURNS_DEEP_STUBS);
+		final RoutePoint routePoint = mock();
+		when(routePoint.getX()).thenReturn(0);
+		when(routePoint.getY()).thenReturn(0);
+		when(ship.getNav().getRoute().getDestination()).thenReturn(routePoint);
+
+		final FuelStatus fuel = new FuelStatus(150, 150);
+		when(ship.getFuel()).thenReturn(fuel);
+
+		// Enough fuel to go from origin to any of the intermediate waypoints, but not
+		// right to the destination
+		final NavigationPath path = calculator.determineShortestRoute(ship, destination);
+
+		assertEquals(200, path.getLength(), 1e-9);
+		assertEquals(List.of(way3, destination), path.getWaypoints());
+	}
+
+	/**
+	 * Tests the case where there is not enough max fuel to reach the destination
+	 */
+	@Test
+	public void notEnoughFuel() {
+
+		final Waypoint origin = makeWaypoint(0, 0);
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		final Waypoint way3 = makeWaypoint(100, 0);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		// Destination is much farther away this time
+		final Waypoint destination = makeWaypoint(2000, 0);
+
+		// Quickest route is through way3
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(way1, way2, way3, way4, way5));
+
+		// Enough fuel to reach the intermediate points, but not the destination
+		final NavigationPath path = calculator.determineShortestRoute(origin, destination, 201, 201);
+
+		assertNull(path);
+	}
+
+	/**
+	 * Tests the case where there is not enough current fuel to reach anything
+	 */
+	@Test
+	public void notEnoughFuelForFirstHop() {
+
+		final Waypoint origin = makeWaypoint(0, 0);
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		final Waypoint way3 = makeWaypoint(100, 0);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		final Waypoint destination = makeWaypoint(200, 0);
+
+		// Quickest route is through way3
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(way1, way2, way3, way4, way5));
+
+		// Not enough current fuel to go anywhere, but would be enough if we could refuel
+		final NavigationPath path = calculator.determineShortestRoute(origin, destination, 1, 200);
+
+		assertNull(path);
+	}
+
+	/**
+	 * Tests the case where the best route goes straight from the origin to the destination
+	 */
+	@Test
+	public void straightShot() {
+
+		final Waypoint origin = makeWaypoint(0, 0);
+
+		// The intermediate waypoints exist on the line x = 100
+		final Waypoint way1 = makeWaypoint(100, -20);
+		final Waypoint way2 = makeWaypoint(100, -10);
+		// Slightly offset this one, otherwise hitting it would be the same distance as the straight shot
+		final Waypoint way3 = makeWaypoint(100, 1);
+		final Waypoint way4 = makeWaypoint(100, 10);
+		final Waypoint way5 = makeWaypoint(100, 20);
+
+		final Waypoint destination = makeWaypoint(200, 0);
+
+		final RefuelPathCalculator calculator = new RefuelPathCalculator();
+		calculator.loadRefuelWaypoints(List.of(way1, way2, way3, way4, way5));
+
+		// Has enough fuel to go right to the destination
+		final NavigationPath path = calculator.determineShortestRoute(origin, destination, 201, 201);
+
+		assertEquals(200, path.getLength(), 1e-9);
+		assertEquals(List.of(destination), path.getWaypoints());
+	}
+
+	private Waypoint makeWaypoint(final int x, final int y) {
+		final Waypoint way = new Waypoint();
+		way.setX(x);
+		way.setY(y);
+		return way;
+	}
+
+}

--- a/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
+++ b/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
@@ -2,6 +2,7 @@ package org.psu.spacetraders.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -111,6 +112,44 @@ public class TradeRouteTest {
 		final TradeRoute route = new TradeRoute(exportWaypoint, importWaypoint, List.of());
 
 		assertEquals(5.0, route.getDistance(), 1e-9);
+	}
+
+	/**
+	 * Tests the equals and hashCode methods
+	 */
+	@SuppressWarnings("unlikely-arg-type")
+	@Test
+	public void equalsAndHashCode() {
+
+		final Waypoint way1 = new Waypoint();
+		way1.setSymbol("way1");
+		final Waypoint way2 = new Waypoint();
+		way2.setSymbol("way2");
+		final Waypoint way3 = new Waypoint();
+		way3.setSymbol("way3");
+
+		final Product product = new Product("milk");
+
+		final TradeRoute route1 = new TradeRoute(way1, way2, List.of(product));
+
+		// Different export waypoint
+		final TradeRoute route2 = new TradeRoute(way3, way2, List.of(product));
+		assertFalse(route1.equals(route2));
+		assertNotEquals(route1.hashCode(), route2.hashCode());
+
+		// Different import waypoint
+		final TradeRoute route3 = new TradeRoute(way1, way3, List.of(product));
+		assertFalse(route1.equals(route3));
+		assertNotEquals(route1.hashCode(), route3.hashCode());
+
+		// Different products, should be equal
+		final TradeRoute route4 = new TradeRoute(way1, way2, List.of());
+		assertTrue(route1.equals(route4));
+		assertEquals(route1.hashCode(), route4.hashCode());
+
+		final Integer notARoute = 1;
+		assertFalse(route1.equals(notARoute));
+		assertNotEquals(route1.hashCode(), notARoute.hashCode());
 	}
 
 }


### PR DESCRIPTION
Adds the RefuelPathCalculator to calculate paths for trade routes which use more than just the export and import waypoints. Refactors the TradeShipManager to utilize routes with multiple stops along the way.