### PR TITLE
Use Queues for Routes

### DIFF
--- a/java/src/main/java/org/psu/navigation/NavigationPath.java
+++ b/java/src/main/java/org/psu/navigation/NavigationPath.java
@@ -1,6 +1,8 @@
 package org.psu.navigation;
 
-import java.util.List;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.psu.spacetraders.dto.Waypoint;
@@ -14,12 +16,12 @@ import lombok.Data;
 public class NavigationPath {
 
 	private final double length;
-	private final List<Waypoint> waypoints;
+	private final Queue<Waypoint> waypoints;
 
 	public static NavigationPath combine(final NavigationPath path1, final NavigationPath path2) {
 		final double totalLength = path1.getLength() + path2.getLength();
-		final List<Waypoint> allWaypoints = Stream.concat(path1.getWaypoints().stream(), path2.getWaypoints().stream())
-				.toList();
+		final Queue<Waypoint> allWaypoints = Stream.concat(path1.getWaypoints().stream(), path2.getWaypoints().stream())
+				.collect(Collectors.toCollection(LinkedList::new));
 		return new NavigationPath(totalLength, allWaypoints);
 	}
 

--- a/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
+++ b/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
@@ -1,7 +1,10 @@
 package org.psu.navigation;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
+import java.util.stream.Collectors;
 
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
@@ -111,11 +114,13 @@ public class RefuelPathCalculator {
 			return null;
 		}
 
-		final List<Waypoint> waypointList = shortestPath.getVertexList();
+		final Queue<Waypoint> waypoints = shortestPath.getVertexList().stream()
+				.collect(Collectors.toCollection(LinkedList::new));
 		final double totalLength = shortestPath.getWeight();
 
 		// Be sure to strip out the origin
-		return new NavigationPath(totalLength, waypointList.subList(1, waypointList.size()));
+		waypoints.remove();
+		return new NavigationPath(totalLength, waypoints);
 
 	}
 

--- a/java/src/main/java/org/psu/trademanager/RouteManager.java
+++ b/java/src/main/java/org/psu/trademanager/RouteManager.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.stream.Collectors;
 
 import org.psu.init.RandomProvider;
@@ -189,7 +190,7 @@ public class RouteManager {
 		return NavigationPath.combine(pathToExport, routePath);
 	}
 
-	public record RouteResponse(TradeRoute route, List<Waypoint> waypoints) {};
+	public record RouteResponse(TradeRoute route, Queue<Waypoint> waypoints) {};
 
 	private record RouteProfit(Integer profit, Product itemToSell) {};
 

--- a/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
@@ -1,7 +1,7 @@
 package org.psu.trademanager.dto;
 
 import java.time.Instant;
-import java.util.List;
+import java.util.Queue;
 
 import org.psu.shiporchestrator.ShipJob;
 import org.psu.spacetraders.dto.Ship;
@@ -24,11 +24,11 @@ public class TradeShipJob implements ShipJob {
 	/**
 	 * The path to take for this trade route. Can be null if the route is being started in the middle
 	 */
-	private List<Waypoint> waypoints;
+	private Queue<Waypoint> waypoints;
 	private Instant nextAction;
 	private State state;
 
-	public TradeShipJob(final Ship ship, final TradeRoute route, final List<Waypoint> waypoints) {
+	public TradeShipJob(final Ship ship, final TradeRoute route, final Queue<Waypoint> waypoints) {
 		this.ship = ship;
 		this.route = route;
 		this.waypoints = waypoints;

--- a/java/src/test/java/org/psu/navigation/NavigationPathTest.java
+++ b/java/src/test/java/org/psu/navigation/NavigationPathTest.java
@@ -1,9 +1,11 @@
 package org.psu.navigation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
-import java.util.List;
+import java.util.LinkedList;
+import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
 import org.psu.spacetraders.dto.Waypoint;
@@ -22,16 +24,24 @@ public class NavigationPathTest {
 		final double len1 = 5.67;
 		final Waypoint way1 = mock();
 		final Waypoint way2 = mock();
-		final NavigationPath path1 = new NavigationPath(len1, List.of(way1, way2));
+		final Queue<Waypoint> ways = new LinkedList<>();
+		ways.add(way1);
+		ways.add(way2);
+		final NavigationPath path1 = new NavigationPath(len1, ways);
 
 		final double len2 = 1.23;
 		final Waypoint way3 = mock();
-		final NavigationPath path2 = new NavigationPath(len2, List.of(way3));
+		final Queue<Waypoint> ways2 = new LinkedList<>();
+		ways2.add(way3);
+		final NavigationPath path2 = new NavigationPath(len2, ways2);
 
 		final NavigationPath combinedPath = NavigationPath.combine(path1, path2);
 
 		assertEquals(len1 + len2, combinedPath.getLength(), 1e-9);
-		assertEquals(List.of(way1, way2, way3), combinedPath.getWaypoints());
+		assertEquals(way1, combinedPath.getWaypoints().poll());
+		assertEquals(way2, combinedPath.getWaypoints().poll());
+		assertEquals(way3, combinedPath.getWaypoints().poll());
+		assertNull(combinedPath.getWaypoints().poll());
 	}
 
 }

--- a/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
@@ -9,8 +9,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.psu.init.RandomProvider;
@@ -108,7 +112,7 @@ public class RouteManagerTest {
 
 		// Path from 1 to 3 is impossible
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(null);
-		final NavigationPath path23 = new NavigationPath(8, List.of(way3));
+		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
@@ -116,7 +120,7 @@ public class RouteManagerTest {
 
 		// Ship cannot travel to 2
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(null);
-		final NavigationPath pathS1 = new NavigationPath(1, List.of(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		// Thus, the 1-3 and 2-3 trade routes are both impossible
@@ -169,18 +173,20 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, List.of(way3));
+		final Queue<Waypoint> path23Ways = new LinkedList<>();
+		path23Ways.add(way3);
+		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, List.of(way3));
+		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2
-		final NavigationPath pathS2 = new NavigationPath(0, List.of(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, List.of(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -198,7 +204,9 @@ public class RouteManagerTest {
 		assertEquals(way3, bestRoute.route().getImportWaypoint());
 		assertEquals(List.of(prod2), bestRoute.route().getGoods());
 		assertFalse(bestRoute.route().isKnown());
-		assertEquals(List.of(way2, way3), bestRoute.waypoints());
+		assertEquals(way2, bestRoute.waypoints().poll());
+		assertEquals(way3, bestRoute.waypoints().poll());
+		assertNull(bestRoute.waypoints().poll());
 	}
 
 	/**
@@ -241,18 +249,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, List.of(way3));
+		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, List.of(way3));
+		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2
-		final NavigationPath pathS2 = new NavigationPath(0, List.of(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, List.of(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -270,7 +278,9 @@ public class RouteManagerTest {
 		assertEquals(way3, bestRoute.route().getImportWaypoint());
 		assertEquals(List.of(prod1), bestRoute.route().getGoods());
 		assertTrue(bestRoute.route().isKnown());
-		assertEquals(List.of(way1, way3), bestRoute.waypoints());
+		assertEquals(way1, bestRoute.waypoints().poll());
+		assertEquals(way3, bestRoute.waypoints().poll());
+		assertNull(bestRoute.waypoints().poll());
 	}
 
 	/**
@@ -314,18 +324,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, List.of(way3));
+		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, List.of(way3));
+		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2, so the route using way2 will be shorter
-		final NavigationPath pathS2 = new NavigationPath(0, List.of(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, List.of(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -343,7 +353,9 @@ public class RouteManagerTest {
 		assertEquals(way3, bestRoute.route().getImportWaypoint());
 		assertEquals(List.of(prod1), bestRoute.route().getGoods());
 		assertFalse(bestRoute.route().isKnown());
-		assertEquals(List.of(way2, way3), bestRoute.waypoints());
+		assertEquals(way2, bestRoute.waypoints().poll());
+		assertEquals(way3, bestRoute.waypoints().poll());
+		assertNull(bestRoute.waypoints().poll());
 	}
 
 	/**
@@ -390,18 +402,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, List.of(way3));
+		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, List.of(way3));
+		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2, so the route using way2 will be shorter
-		final NavigationPath pathS2 = new NavigationPath(0, List.of(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, List.of(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -423,7 +435,9 @@ public class RouteManagerTest {
 		assertEquals(way3, bestRoute.route().getImportWaypoint());
 		assertEquals(List.of(prod1), bestRoute.route().getGoods());
 		assertTrue(bestRoute.route().isKnown());
-		assertEquals(List.of(way1, way3), bestRoute.waypoints());
+		assertEquals(way1, bestRoute.waypoints().poll());
+		assertEquals(way3, bestRoute.waypoints().poll());
+		assertNull(bestRoute.waypoints().poll());
 
 		// Now, return a large double, this means we will go with the shortest route
 		when(randomProvider.nextDouble()).thenReturn(1.0);
@@ -434,7 +448,13 @@ public class RouteManagerTest {
 		assertEquals(way3, nextBestRoute.route().getImportWaypoint());
 		assertEquals(List.of(prod1, prod2), nextBestRoute.route().getGoods());
 		assertFalse(nextBestRoute.route().isKnown());
-		assertEquals(List.of(way2, way3), nextBestRoute.waypoints());
+		assertEquals(way2, nextBestRoute.waypoints().poll());
+		assertEquals(way3, nextBestRoute.waypoints().poll());
+		assertNull(nextBestRoute.waypoints().poll());
+	}
+
+	private Queue<Waypoint> makeQueue(Waypoint... waypoints) {
+		return Stream.of(waypoints).collect(Collectors.toCollection(LinkedList::new));
 	}
 
 }

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -13,8 +13,10 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
@@ -56,7 +58,9 @@ public class TradeShipManagerTest {
 		final RouteManager routeManager = mock();
 		final TradeRoute route = mock();
 		final Waypoint way = mock();
-		final RouteResponse routeResponse = new RouteResponse(route, List.of(way));
+		final Queue<Waypoint> ways = new LinkedList<>();
+		ways.add(way);
+		final RouteResponse routeResponse = new RouteResponse(route, ways);
 		when(routeManager.getBestRoute(ship)).thenReturn(routeResponse);
 		final WebsocketReporter reporter = mock();
 
@@ -147,7 +151,10 @@ public class TradeShipManagerTest {
 		final Instant arrivalTime = Instant.now().plus(Duration.ofMillis(10));
 		when(navHelper.navigate(ship, exportWaypoint)).thenReturn(arrivalTime);
 
-		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, List.of(exportWaypoint));
+		final Queue<Waypoint> exports = new LinkedList<>();
+		exports.add(exportWaypoint);
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, exports);
 
 		final TradeShipJob outputJob = manager.manageTradeShip(job);
 
@@ -204,7 +211,10 @@ public class TradeShipManagerTest {
 		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(marketRequester.purchase(any(), same(tradeRequest))).thenReturn(tradeResponse);
 
-		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, List.of(importWaypoint));
+		final Queue<Waypoint> imports = new LinkedList<>();
+		imports.add(importWaypoint);
+
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, imports);
 		job.setState(State.TRAVELING);
 
 		final TradeShipJob outputJob = manager.manageTradeShip(job);
@@ -249,10 +259,12 @@ public class TradeShipManagerTest {
 
 		final TradeRoute newTradeRoute = mock();
 		final Waypoint way = mock();
-		final RouteResponse routeResponse = new RouteResponse(newTradeRoute, List.of(way));
+		final Queue<Waypoint> ways = new LinkedList<>();
+		ways.add(way);
+		final RouteResponse routeResponse = new RouteResponse(newTradeRoute, ways);
 		when(routeManager.getBestRoute(ship)).thenReturn(routeResponse);
 
-		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, List.of());
+		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, new LinkedList<>());
 		job.setState(State.TRAVELING);
 
 		when(marketRequester.dockAndSellItems(ship, importWaypoint, List.of(cargoItem))).thenReturn(10);


### PR DESCRIPTION
Uses the Queue data type for path calculations because they facilitate easier removal at the head, which is what the ship managers will do.