### PR TITLE
Multi Stop Routes in Mining Manager

### DIFF
--- a/java/src/main/java/org/psu/miningmanager/dto/MiningShipJob.java
+++ b/java/src/main/java/org/psu/miningmanager/dto/MiningShipJob.java
@@ -1,7 +1,10 @@
 package org.psu.miningmanager.dto;
 
 import java.time.Instant;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 import org.psu.shiporchestrator.ShipJob;
 import org.psu.spacetraders.dto.Ship;
@@ -20,6 +23,7 @@ import lombok.Setter;
 public class MiningShipJob implements ShipJob {
 
 	private Ship ship;
+	private Queue<Waypoint> extractionPath;
 	private Waypoint extractionPoint;
 	private Instant nextAction;
 	/**
@@ -27,17 +31,20 @@ public class MiningShipJob implements ShipJob {
 	 */
 	private List<Survey> surveys;
 	/**
-	 * This will only be populated after resources have been extracted
+	 * The selling path and point will only be populated after resources have been extracted
 	 */
-	private Waypoint sellingWaypoint;
+	private Queue<Waypoint> sellingPath;
+	private Waypoint sellingPoint;
 	private State state;
 
-	public MiningShipJob(final Ship ship, final Waypoint extractionPoint) {
+	public MiningShipJob(final Ship ship, final Deque<Waypoint> extractionPath) {
 		this.ship = ship;
-		this.extractionPoint = extractionPoint;
+		this.extractionPath = extractionPath;
+		this.extractionPoint = extractionPath.peekLast();
 		this.nextAction = Instant.now();
 		this.surveys = null;
-		this.sellingWaypoint = null;
+		this.sellingPath = new LinkedList<>();
+		this.sellingPoint = null;
 		this.state = State.NOT_STARTED;
 	}
 

--- a/java/src/main/java/org/psu/navigation/NavigationPath.java
+++ b/java/src/main/java/org/psu/navigation/NavigationPath.java
@@ -1,7 +1,7 @@
 package org.psu.navigation;
 
+import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -16,11 +16,11 @@ import lombok.Data;
 public class NavigationPath {
 
 	private final double length;
-	private final Queue<Waypoint> waypoints;
+	private final Deque<Waypoint> waypoints;
 
 	public static NavigationPath combine(final NavigationPath path1, final NavigationPath path2) {
 		final double totalLength = path1.getLength() + path2.getLength();
-		final Queue<Waypoint> allWaypoints = Stream.concat(path1.getWaypoints().stream(), path2.getWaypoints().stream())
+		final Deque<Waypoint> allWaypoints = Stream.concat(path1.getWaypoints().stream(), path2.getWaypoints().stream())
 				.collect(Collectors.toCollection(LinkedList::new));
 		return new NavigationPath(totalLength, allWaypoints);
 	}

--- a/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
+++ b/java/src/main/java/org/psu/navigation/RefuelPathCalculator.java
@@ -1,9 +1,9 @@
 package org.psu.navigation;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
 import java.util.stream.Collectors;
 
 import org.jgrapht.GraphPath;
@@ -114,7 +114,7 @@ public class RefuelPathCalculator {
 			return null;
 		}
 
-		final Queue<Waypoint> waypoints = shortestPath.getVertexList().stream()
+		final Deque<Waypoint> waypoints = shortestPath.getVertexList().stream()
 				.collect(Collectors.toCollection(LinkedList::new));
 		final double totalLength = shortestPath.getWeight();
 

--- a/java/src/test/java/org/psu/miningmanager/MiningSiteManagerTest.java
+++ b/java/src/test/java/org/psu/miningmanager/MiningSiteManagerTest.java
@@ -6,14 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
+import org.psu.navigation.NavigationPath;
+import org.psu.navigation.RefuelPathCalculator;
 import org.psu.spacetraders.dto.Ship;
 import org.psu.spacetraders.dto.Trait;
 import org.psu.spacetraders.dto.Trait.Type;
 import org.psu.spacetraders.dto.Waypoint;
+import org.psu.testutils.TestUtils;
 
 /**
  * Tests for {@link MiningSiteManager}
@@ -29,25 +34,29 @@ public class MiningSiteManagerTest {
 		final Trait miningTrait = new Trait(Type.COMMON_METAL_DEPOSITS);
 		final Trait nonMiningTrait = new Trait(Type.DEEP_CRATERS);
 
-		final Ship ship = mock(Ship.class);
+		final RefuelPathCalculator pathCalculator = mock();
+		final Ship ship = mock();
 
 		final String closeMiningSiteId = "closeMiningSite";
 		final Waypoint closeMiningSite = mock(Waypoint.class);
 		when(closeMiningSite.getSymbol()).thenReturn(closeMiningSiteId);
 		when(closeMiningSite.getTraits()).thenReturn(List.of(miningTrait, nonMiningTrait));
-		when(ship.distTo(closeMiningSite)).thenReturn(1.0);
+		when(pathCalculator.determineShortestRoute(ship, closeMiningSite))
+				.thenReturn(new NavigationPath(1.0, TestUtils.makeQueue(closeMiningSite)));
 
 		final String mediumMiningSiteId = "mediumMiningSite";
 		final Waypoint mediumMiningSite = mock(Waypoint.class);
 		when(mediumMiningSite.getSymbol()).thenReturn(mediumMiningSiteId);
 		when(mediumMiningSite.getTraits()).thenReturn(List.of(miningTrait));
-		when(ship.distTo(mediumMiningSite)).thenReturn(2.0);
+		when(pathCalculator.determineShortestRoute(ship, mediumMiningSite))
+				.thenReturn(new NavigationPath(2.0, TestUtils.makeQueue(mediumMiningSite)));
 
 		final String farMiningSiteId = "farMiningSite";
 		final Waypoint farMiningSite = mock(Waypoint.class);
 		when(farMiningSite.getSymbol()).thenReturn(farMiningSiteId);
 		when(farMiningSite.getTraits()).thenReturn(List.of(miningTrait, nonMiningTrait));
-		when(ship.distTo(farMiningSite)).thenReturn(3.0);
+		when(pathCalculator.determineShortestRoute(ship, farMiningSite))
+				.thenReturn(new NavigationPath(2.0, TestUtils.makeQueue(farMiningSite)));
 
 		final String nonMiningSiteId = "nonMiningSite";
 		final Waypoint nonMiningSite = mock(Waypoint.class);
@@ -55,12 +64,14 @@ public class MiningSiteManagerTest {
 		when(nonMiningSite.getTraits()).thenReturn(List.of(nonMiningTrait));
 		when(ship.distTo(nonMiningSite)).thenReturn(0.1);
 
-		final MiningSiteManager manager = new MiningSiteManager();
+		final MiningSiteManager manager = new MiningSiteManager(pathCalculator);
 		manager.addSites(List.of(nonMiningSite, closeMiningSite, mediumMiningSite, farMiningSite));
 
-		final Optional<Waypoint> closestMiningSite = manager.getClosestMiningSite(ship);
+		final Optional<Deque<Waypoint>> closestMiningSite = manager.getClosestMiningSite(ship);
 		assertTrue(closestMiningSite.isPresent());
-		assertEquals(closeMiningSite, closestMiningSite.get());
+		final Queue<Waypoint> path = closestMiningSite.get();
+		assertEquals(closeMiningSite, path.poll());
+		assertNull(path.poll());
 
 		assertEquals(closeMiningSite, manager.getMiningSite(closeMiningSiteId));
 		assertEquals(mediumMiningSite, manager.getMiningSite(mediumMiningSiteId));

--- a/java/src/test/java/org/psu/navigation/NavigationPathTest.java
+++ b/java/src/test/java/org/psu/navigation/NavigationPathTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
+import java.util.Deque;
 import java.util.LinkedList;
-import java.util.Queue;
 
 import org.junit.jupiter.api.Test;
 import org.psu.spacetraders.dto.Waypoint;
@@ -24,14 +24,14 @@ public class NavigationPathTest {
 		final double len1 = 5.67;
 		final Waypoint way1 = mock();
 		final Waypoint way2 = mock();
-		final Queue<Waypoint> ways = new LinkedList<>();
+		final Deque<Waypoint> ways = new LinkedList<>();
 		ways.add(way1);
 		ways.add(way2);
 		final NavigationPath path1 = new NavigationPath(len1, ways);
 
 		final double len2 = 1.23;
 		final Waypoint way3 = mock();
-		final Queue<Waypoint> ways2 = new LinkedList<>();
+		final Deque<Waypoint> ways2 = new LinkedList<>();
 		ways2.add(way3);
 		final NavigationPath path2 = new NavigationPath(len2, ways2);
 

--- a/java/src/test/java/org/psu/testutils/TestUtils.java
+++ b/java/src/test/java/org/psu/testutils/TestUtils.java
@@ -1,0 +1,23 @@
+package org.psu.testutils;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Miscellaneous test utilities
+ */
+public class TestUtils {
+
+	/**
+	 * @param <T> The type of items
+	 * @param items The items
+	 * @return A queue of the items, in the order they were input
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> Deque<T> makeQueue(T... items) {
+		return Stream.of(items).collect(Collectors.toCollection(LinkedList::new));
+	}
+
+}

--- a/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/RouteManagerTest.java
@@ -13,8 +13,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.psu.init.RandomProvider;
@@ -26,6 +24,7 @@ import org.psu.spacetraders.dto.Product;
 import org.psu.spacetraders.dto.Ship;
 import org.psu.spacetraders.dto.TradeGood;
 import org.psu.spacetraders.dto.Waypoint;
+import org.psu.testutils.TestUtils;
 import org.psu.trademanager.RouteManager.RouteResponse;
 import org.psu.trademanager.dto.TradeRoute;
 
@@ -112,7 +111,7 @@ public class RouteManagerTest {
 
 		// Path from 1 to 3 is impossible
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(null);
-		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
+		final NavigationPath path23 = new NavigationPath(8, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
@@ -120,7 +119,7 @@ public class RouteManagerTest {
 
 		// Ship cannot travel to 2
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(null);
-		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, TestUtils.makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		// Thus, the 1-3 and 2-3 trade routes are both impossible
@@ -175,18 +174,18 @@ public class RouteManagerTest {
 		// Way2 is closer to Way3 than Way1 is
 		final Queue<Waypoint> path23Ways = new LinkedList<>();
 		path23Ways.add(way3);
-		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
+		final NavigationPath path13 = new NavigationPath(10, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
+		final NavigationPath path23 = new NavigationPath(8, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2
-		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, TestUtils.makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, TestUtils.makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -249,18 +248,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
+		final NavigationPath path13 = new NavigationPath(10, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
+		final NavigationPath path23 = new NavigationPath(8, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2
-		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, TestUtils.makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, TestUtils.makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -324,18 +323,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
+		final NavigationPath path13 = new NavigationPath(10, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
+		final NavigationPath path23 = new NavigationPath(8, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2, so the route using way2 will be shorter
-		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, TestUtils.makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, TestUtils.makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -402,18 +401,18 @@ public class RouteManagerTest {
 		final RefuelPathCalculator pathCalculator = mock();
 
 		// Way2 is closer to Way3 than Way1 is
-		final NavigationPath path13 = new NavigationPath(10, makeQueue(way3));
+		final NavigationPath path13 = new NavigationPath(10, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way1), eq(way3), anyInt(), anyInt())).thenReturn(path13);
-		final NavigationPath path23 = new NavigationPath(8, makeQueue(way3));
+		final NavigationPath path23 = new NavigationPath(8, TestUtils.makeQueue(way3));
 		when(pathCalculator.determineShortestRoute(eq(way2), eq(way3), anyInt(), anyInt())).thenReturn(path23);
 
 		final Ship ship = mock();
 		when(ship.getFuel()).thenReturn(new FuelStatus(0, 0));
 
 		// Ship is at way2, so the route using way2 will be shorter
-		final NavigationPath pathS2 = new NavigationPath(0, makeQueue(way2));
+		final NavigationPath pathS2 = new NavigationPath(0, TestUtils.makeQueue(way2));
 		when(pathCalculator.determineShortestRoute(ship, way2)).thenReturn(pathS2);
-		final NavigationPath pathS1 = new NavigationPath(1, makeQueue(way1));
+		final NavigationPath pathS1 = new NavigationPath(1, TestUtils.makeQueue(way1));
 		when(pathCalculator.determineShortestRoute(ship, way1)).thenReturn(pathS1);
 
 		final MarketplaceManager marketplaceManager = mock(MarketplaceManager.class);
@@ -451,10 +450,6 @@ public class RouteManagerTest {
 		assertEquals(way2, nextBestRoute.waypoints().poll());
 		assertEquals(way3, nextBestRoute.waypoints().poll());
 		assertNull(nextBestRoute.waypoints().poll());
-	}
-
-	private Queue<Waypoint> makeQueue(Waypoint... waypoints) {
-		return Stream.of(waypoints).collect(Collectors.toCollection(LinkedList::new));
 	}
 
 }


### PR DESCRIPTION
Adds support for routes with multiple stops in the mining ship manager. This includes routes to the extraction site and to the selling waypoint.