### PR TITLE
Track Profit in Multi Stop Routes

### DIFF
--- a/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeRoute.java
@@ -22,11 +22,6 @@ public class TradeRoute {
 	private final Waypoint importWaypoint;
 	private List<Product> goods;
 	/**
-	 * This will only be populated after purchasing items at the export waypoint,
-	 * and will never be populated for a route which starts in the middle
-	 */
-	private Integer purchasePrice;
-	/**
 	 * An unknown trade route is one where the prices are not known at either the
 	 * export or the import, or both
 	 */
@@ -36,7 +31,6 @@ public class TradeRoute {
 		this.exportWaypoint = exportWaypoint;
 		this.importWaypoint = importWaypoint;
 		this.goods = goods;
-		this.purchasePrice = null;
 		this.isKnown = false;
 	}
 

--- a/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
+++ b/java/src/main/java/org/psu/trademanager/dto/TradeShipJob.java
@@ -26,6 +26,7 @@ public class TradeShipJob implements ShipJob {
 	 */
 	private Queue<Waypoint> waypoints;
 	private Instant nextAction;
+	private int profit;
 	private State state;
 
 	public TradeShipJob(final Ship ship, final TradeRoute route, final Queue<Waypoint> waypoints) {
@@ -33,7 +34,15 @@ public class TradeShipJob implements ShipJob {
 		this.route = route;
 		this.waypoints = waypoints;
 		this.nextAction = Instant.now();
+		this.profit = 0;
 		this.state = State.NOT_STARTED;
+	}
+
+	/**
+	 * @param income The amount of credits gained. If a cost is incurred this should be negative.
+	 */
+	public void modifyProfit(final int income) {
+		this.profit += income;
 	}
 
 	public static enum State {

--- a/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
+++ b/java/src/test/java/org/psu/spacetraders/dto/TradeRouteTest.java
@@ -3,7 +3,6 @@ package org.psu.spacetraders.dto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,7 +32,6 @@ public class TradeRouteTest {
 		assertEquals(exportWaypoint, route.getExportWaypoint());
 		assertEquals(goods, route.getGoods());
 		assertFalse(route.isKnown());
-		assertNull(route.getPurchasePrice());
 	}
 
 	/**

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -27,6 +27,7 @@ import org.psu.spacetraders.dto.Cargo;
 import org.psu.spacetraders.dto.CargoItem;
 import org.psu.spacetraders.dto.MarketInfo;
 import org.psu.spacetraders.dto.Product;
+import org.psu.spacetraders.dto.RefuelResponse;
 import org.psu.spacetraders.dto.Ship;
 import org.psu.spacetraders.dto.ShipNavigation;
 import org.psu.spacetraders.dto.TradeRequest;
@@ -207,9 +208,16 @@ public class TradeShipManagerTest {
 		when(marketManager.updateMarketInfo(exportWaypoint)).thenReturn(marketInfo);
 
 		final Transaction transaction = mock(Transaction.class);
+		when(transaction.getTotalPrice()).thenReturn(100);
 		final TradeResponse tradeResponse = mock(TradeResponse.class);
 		when(tradeResponse.getTransaction()).thenReturn(transaction);
 		when(marketRequester.purchase(any(), same(tradeRequest))).thenReturn(tradeResponse);
+
+		final Transaction refuelTransaction = mock();
+		when(refuelTransaction.getTotalPrice()).thenReturn(10);
+		final RefuelResponse refuelResponse = mock();
+		when(refuelResponse.getTransaction()).thenReturn(refuelTransaction);
+		when(marketRequester.refuel(ship)).thenReturn(refuelResponse);
 
 		final Queue<Waypoint> imports = new LinkedList<>();
 		imports.add(importWaypoint);
@@ -221,6 +229,8 @@ public class TradeShipManagerTest {
 
 		assertEquals(State.TRAVELING, outputJob.getState());
 		assertEquals(arrivalTime, outputJob.getNextAction());
+		// 100 credits for the purchase, 10 for refueling
+		assertEquals(-110, outputJob.getProfit());
 	}
 
 	/**


### PR DESCRIPTION
Updates the Trade Ship Manager to track profit correctly given that the ship can refuel multiple times during its routes.