### PR TITLE
Speed up Test Driver

### DIFF
--- a/java/src/main/java/org/psu/spacetraders/api/MarketplaceRequester.java
+++ b/java/src/main/java/org/psu/spacetraders/api/MarketplaceRequester.java
@@ -3,6 +3,7 @@ package org.psu.spacetraders.api;
 import java.time.Duration;
 import java.util.List;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.psu.spacetraders.dto.CargoItem;
 import org.psu.spacetraders.dto.MarketInfo;
 import org.psu.spacetraders.dto.Product;
@@ -26,6 +27,7 @@ import lombok.extern.jbosslog.JBossLog;
 @ApplicationScoped
 public class MarketplaceRequester {
 
+	private Duration marketUpdateDelay;
 	private MarketplaceClient marketplaceClient;
 	private RequestThrottler throttler;
 	private AccountManager accountManager;
@@ -34,9 +36,11 @@ public class MarketplaceRequester {
 	private WebsocketReporter websocketReporter;
 
 	@Inject
-	public MarketplaceRequester(final ClientProducer clientProducer, final RequestThrottler throttler,
+	public MarketplaceRequester(@ConfigProperty(name = "app.marketupdate-delay-ms") final int marketUpdateDelay,
+			final ClientProducer clientProducer, final RequestThrottler throttler,
 			final AccountManager accountManager, final MarketplaceManager marketplaceManager,
 			final NavigationHelper navHelper, final WebsocketReporter websocketReporter) {
+		this.marketUpdateDelay = Duration.ofMillis(marketUpdateDelay);
 		this.marketplaceClient = clientProducer.produceMarketplaceClient();
 		this.throttler = throttler;
 		this.accountManager = accountManager;
@@ -106,7 +110,7 @@ public class MarketplaceRequester {
 		// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
 		// a ship is docked at them
 		try {
-			Thread.sleep(Duration.ofSeconds(5));
+			Thread.sleep(marketUpdateDelay);
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 		}

--- a/java/src/main/java/org/psu/spacetraders/api/RequestThrottler.java
+++ b/java/src/main/java/org/psu/spacetraders/api/RequestThrottler.java
@@ -22,10 +22,12 @@ import lombok.extern.jbosslog.JBossLog;
 @ApplicationScoped
 public class RequestThrottler {
 
+	private final boolean enabled;
 	private final List<RateLimiter> rateLimiters;
 
 	@Inject
 	public RequestThrottler(final ThrottlerConfig config) {
+		this.enabled = config.enabled();
 		this.rateLimiters = config.rateLimiters().stream().map(c -> new RateLimiter(c)).toList();
 	}
 
@@ -40,6 +42,9 @@ public class RequestThrottler {
 	 * @return The result of invoking the supplier.
 	 */
 	public <T> T throttle(Supplier<T> apiInteraction) {
+		if (!this.enabled) {
+			return apiInteraction.get();
+		}
 
 		// The time when the api interaction can be performed.
 		// If empty, the interaction can be performed immediately

--- a/java/src/main/java/org/psu/spacetraders/api/ThrottlerConfig.java
+++ b/java/src/main/java/org/psu/spacetraders/api/ThrottlerConfig.java
@@ -10,6 +10,7 @@ import io.smallrye.config.ConfigMapping;
 @ConfigMapping(prefix = "app.throttler")
 public interface ThrottlerConfig {
 
+	boolean enabled();
 	List<RateLimiterConfig> rateLimiters();
 
 	/**

--- a/java/src/main/java/org/psu/testdriver/client/LocalNavigationClient.java
+++ b/java/src/main/java/org/psu/testdriver/client/LocalNavigationClient.java
@@ -82,7 +82,7 @@ public class LocalNavigationClient implements NavigationClient {
 		shipNav.setWaypointSymbol(destination.getSymbol());
 
 		final Instant departureTime = Instant.now();
-		final Duration travelTime = Duration.ofMillis(1).multipliedBy(navDelayMsPerUnit);
+		final Duration travelTime = Duration.ofMillis((int) dist).multipliedBy(navDelayMsPerUnit);
 		shipNav.getRoute().setDepartureTime(departureTime);
 		shipNav.getRoute().setArrival(departureTime.plus(travelTime));
 

--- a/java/src/main/java/org/psu/trademanager/TradeShipManager.java
+++ b/java/src/main/java/org/psu/trademanager/TradeShipManager.java
@@ -39,6 +39,7 @@ import lombok.extern.jbosslog.JBossLog;
 public class TradeShipManager {
 
 	private Duration navigationPad;
+	private Duration marketUpdateDelay;
 	private NavigationHelper navigationHelper;
 	private AccountManager accountManager;
 	private MarketplaceRequester marketplaceRequester;
@@ -48,11 +49,13 @@ public class TradeShipManager {
 
 	@Inject
 	public TradeShipManager(@ConfigProperty(name = "app.cooldown-pad-ms") final int navigationPad,
+			@ConfigProperty(name = "app.marketupdate-delay-ms") final int marketUpdateDelay,
 			final NavigationHelper navigationHelper,
 			final AccountManager accountManager, final MarketplaceRequester marketplaceRequester,
 			final MarketplaceManager marketplaceManager, final RouteManager routeManager,
 			final WebsocketReporter websocketReporter) {
 		this.navigationPad = Duration.ofMillis(navigationPad);
+		this.marketUpdateDelay = Duration.ofMillis(marketUpdateDelay);
 		this.navigationHelper = navigationHelper;
 		this.accountManager = accountManager;
 		this.marketplaceRequester = marketplaceRequester;
@@ -162,7 +165,7 @@ public class TradeShipManager {
 		// TODO: Remove this when space traders fixes their bug, it takes a while for markets to realize
 		// a ship is docked at them
 		try {
-			Thread.sleep(Duration.ofSeconds(5));
+			Thread.sleep(marketUpdateDelay);
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 		}

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -1,12 +1,16 @@
 app.max-items-per-page=20
 app.cooldown-pad-ms=3000
+app.marketupdate-delay-ms=5000
 
+app.throttler.enabled=true
 app.throttler.rate-limiters[0].requests=2
 app.throttler.rate-limiters[0].period=1
 app.throttler.rate-limiters[1].requests=30
 app.throttler.rate-limiters[1].period=60
 
-app.test-driver.nav-time-ms-per-unit=0
+%test-driver.app.marketupdate-delay-ms=0
+%test-driver.app.throttler.enabled=false
+app.test-driver.nav-time-ms-per-unit=2
 
 quarkus.http.cors=true
 

--- a/java/src/test/java/org/psu/spacetraders/api/MarketplaceRequesterTest.java
+++ b/java/src/test/java/org/psu/spacetraders/api/MarketplaceRequesterTest.java
@@ -57,8 +57,8 @@ public class MarketplaceRequesterTest {
 		when(client.purchase(shipId, request)).thenReturn(new DataWrapper<TradeResponse>(response, null));
 
 		final RequestThrottler throttler = TestRequestThrottler.get();
-		final MarketplaceRequester requester = new MarketplaceRequester(clientProducer, throttler, manager, null, null,
-				reporter);
+		final MarketplaceRequester requester = new MarketplaceRequester(0, clientProducer, throttler, manager, null,
+				null, reporter);
 
 		final TradeResponse actualResponse = requester.purchase(ship, request);
 		assertEquals(response, actualResponse);
@@ -92,8 +92,8 @@ public class MarketplaceRequesterTest {
 		when(client.sell(shipId, request)).thenReturn(new DataWrapper<TradeResponse>(response, null));
 
 		final RequestThrottler throttler = TestRequestThrottler.get();
-		final MarketplaceRequester requester = new MarketplaceRequester(clientProducer, throttler, manager, null, null,
-				reporter);
+		final MarketplaceRequester requester = new MarketplaceRequester(0, clientProducer, throttler, manager, null,
+				null, reporter);
 
 		final TradeResponse actualResponse = requester.sell(ship, request);
 		assertEquals(response, actualResponse);
@@ -126,8 +126,8 @@ public class MarketplaceRequesterTest {
 		when(client.refuel(shipId)).thenReturn(new DataWrapper<RefuelResponse>(response, null));
 
 		final RequestThrottler throttler = TestRequestThrottler.get();
-		final MarketplaceRequester requester = new MarketplaceRequester(clientProducer, throttler, manager, null, null,
-				reporter);
+		final MarketplaceRequester requester = new MarketplaceRequester(0, clientProducer, throttler, manager, null,
+				null, reporter);
 
 		final RefuelResponse actualResponse = requester.refuel(ship);
 		assertEquals(response, actualResponse);
@@ -149,7 +149,7 @@ public class MarketplaceRequesterTest {
 		final ClientProducer clientProducer = mock();
 		when(clientProducer.produceMarketplaceClient()).thenReturn(client);
 		final RequestThrottler throttler = TestRequestThrottler.get();
-		final MarketplaceRequester requester = new MarketplaceRequester(clientProducer, throttler, accountManager,
+		final MarketplaceRequester requester = new MarketplaceRequester(0, clientProducer, throttler, accountManager,
 				marketplaceManager, navHelper, reporter);
 
 		final List<CargoItem> cargoItems = List.of(new CargoItem("eggs", 1));
@@ -202,7 +202,7 @@ public class MarketplaceRequesterTest {
 		final ClientProducer clientProducer = mock();
 		when(clientProducer.produceMarketplaceClient()).thenReturn(client);
 		final RequestThrottler throttler = TestRequestThrottler.get();
-		final MarketplaceRequester requester = new MarketplaceRequester(clientProducer, throttler, accountManager,
+		final MarketplaceRequester requester = new MarketplaceRequester(0, clientProducer, throttler, accountManager,
 				marketplaceManager, navHelper, reporter);
 
 		final List<CargoItem> cargoItems = List.of(new CargoItem("eggs", 1));

--- a/java/src/test/java/org/psu/spacetraders/api/RequestThrottlerTest.java
+++ b/java/src/test/java/org/psu/spacetraders/api/RequestThrottlerTest.java
@@ -25,6 +25,29 @@ public class RequestThrottlerTest {
 
 		final ThrottlerConfig config = mock(ThrottlerConfig.class);
 		when(config.rateLimiters()).thenReturn(List.of(limiterConfig));
+		when(config.enabled()).thenReturn(true);
+
+		final RequestThrottler throttler = new RequestThrottler(config);
+
+		for (int i = 0; i < 15; i++) {
+			// Throttle a bunch of things
+			throttler.throttle(() -> 1);
+		}
+	}
+
+	/**
+	 * Tests {@link RequestThrottler#throttle} when throttling is disabled
+	 */
+	@Test
+	public void throttleDisabled() {
+
+		final RateLimiterConfig limiterConfig = mock(RateLimiterConfig.class);
+		when(limiterConfig.requests()).thenReturn(10);
+		when(limiterConfig.period()).thenReturn(1);
+
+		final ThrottlerConfig config = mock(ThrottlerConfig.class);
+		when(config.rateLimiters()).thenReturn(List.of(limiterConfig));
+		when(config.enabled()).thenReturn(false);
 
 		final RequestThrottler throttler = new RequestThrottler(config);
 

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -65,7 +65,7 @@ public class TradeShipManagerTest {
 		when(routeManager.getBestRoute(ship)).thenReturn(routeResponse);
 		final WebsocketReporter reporter = mock();
 
-		final TradeShipManager manager = new TradeShipManager(0, null, null, null, null, routeManager, reporter);
+		final TradeShipManager manager = new TradeShipManager(0, 0, null, null, null, null, routeManager, reporter);
 
 		final TradeShipJob job = manager.createJob(ship);
 
@@ -83,7 +83,7 @@ public class TradeShipManagerTest {
 
 		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
 		final WebsocketReporter reporter = mock(WebsocketReporter.class);
-		final TradeShipManager manager = new TradeShipManager(0, null, null, null, marketManager, null, reporter);
+		final TradeShipManager manager = new TradeShipManager(0, 0, null, null, null, marketManager, null, reporter);
 
 		final String product1 = "milk";
 		final int product1Quantity = 5;
@@ -136,7 +136,7 @@ public class TradeShipManagerTest {
 		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
 		final RouteManager routeManager = mock(RouteManager.class);
 		final WebsocketReporter reporter = mock(WebsocketReporter.class);
-		final TradeShipManager manager = new TradeShipManager(0, navHelper, accountManager, marketRequester,
+		final TradeShipManager manager = new TradeShipManager(0, 0, navHelper, accountManager, marketRequester,
 				marketManager, routeManager, reporter);
 
 		final Ship ship = mock(Ship.class);
@@ -179,7 +179,7 @@ public class TradeShipManagerTest {
 		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
 		final RouteManager routeManager = mock(RouteManager.class);
 		final WebsocketReporter reporter = mock(WebsocketReporter.class);
-		final TradeShipManager manager = new TradeShipManager(0, navHelper, accountManager, marketRequester,
+		final TradeShipManager manager = new TradeShipManager(0, 0, navHelper, accountManager, marketRequester,
 				marketManager, routeManager, reporter);
 
 		final String exportWaypointSymbol = "export";
@@ -249,7 +249,7 @@ public class TradeShipManagerTest {
 		final MarketplaceManager marketManager = mock(MarketplaceManager.class);
 		final RouteManager routeManager = mock(RouteManager.class);
 		final WebsocketReporter reporter = mock(WebsocketReporter.class);
-		final TradeShipManager manager = new TradeShipManager(0, navHelper, accountManager, marketRequester,
+		final TradeShipManager manager = new TradeShipManager(0, 0, navHelper, accountManager, marketRequester,
 				marketManager, routeManager, reporter);
 
 		final String importWaypointSymbol = "import";


### PR DESCRIPTION
When the test driver is running, disables the request throttler and the market update delay, both of which are needed to conform with the real API but aren't needed in local mode.