### PR TITLE
Move Job Creation to Queue

### DIFF
--- a/java/src/main/java/org/psu/miningmanager/MiningShipManager.java
+++ b/java/src/main/java/org/psu/miningmanager/MiningShipManager.java
@@ -198,8 +198,8 @@ public class MiningShipManager {
 			if (ship.getNav().getWaypointSymbol().equals(job.getSellingPoint().getSymbol())) {
 				// We've reached the market
 				sellItems(job);
-				// Make a whole new job and return it
-				return createJob(job.getShip());
+				// We've finished the job, now return null for the queue to determine what to do next
+				return null;
 			}
 			// We need to keep traveling along the path
 			final Waypoint nextSellingPathPoint = job.getSellingPath().remove();

--- a/java/src/main/java/org/psu/shiporchestrator/ShipJob.java
+++ b/java/src/main/java/org/psu/shiporchestrator/ShipJob.java
@@ -2,6 +2,8 @@ package org.psu.shiporchestrator;
 
 import java.time.Instant;
 
+import org.psu.spacetraders.dto.Ship;
+
 /**
  * This is the interface that the jobs for all managers will implement, these
  * objects will be stored in the {@link JobQueue}
@@ -12,5 +14,10 @@ public interface ShipJob {
 	 * @return The instant in which the job can be sent back to the relevant ship manager
 	 */
 	public Instant getNextAction();
+
+	/**
+	 * @return The ship that this job is for
+	 */
+	public Ship getShip();
 
 }

--- a/java/src/main/java/org/psu/trademanager/TradeShipManager.java
+++ b/java/src/main/java/org/psu/trademanager/TradeShipManager.java
@@ -135,8 +135,8 @@ public class TradeShipManager {
 			if (ship.getNav().getWaypointSymbol().equals(job.getRoute().getImportWaypoint().getSymbol())) {
 				// We're currently at the import waypoint
 				sellGoods(job);
-				// Make a whole new job and return it
-				return createJob(ship);
+				// We've finished the job, now return null for the queue to determine what to do next
+				return null;
 			}
 
 			// So long as we're not at the import waypoint, there is at least one more waypoint to travel to

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -22,4 +22,4 @@ quarkus.package.output-name=StapleApplication
 
 quarkus.rest-client.logging.scope=request-response
 quarkus.rest-client.logging.body-limit=1024
-#quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
+quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG

--- a/java/src/test/java/org/psu/miningmanager/MiningShipManagerTest.java
+++ b/java/src/test/java/org/psu/miningmanager/MiningShipManagerTest.java
@@ -648,7 +648,7 @@ public class MiningShipManagerTest {
 		final MiningShipJob nextJob = manager.manageMiningShip(job);
 
 		verify(marketRequester).dockAndSellItems(ship, extractionSite, cargoItems);
-		assertEquals(State.NOT_STARTED, nextJob.getState());
+		assertNull(nextJob);
 	}
 
 }

--- a/java/src/test/java/org/psu/shiporchestrator/ShipJobQueueTest.java
+++ b/java/src/test/java/org/psu/shiporchestrator/ShipJobQueueTest.java
@@ -11,10 +11,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.psu.init.ShipJobCreator;
 import org.psu.miningmanager.MiningShipManager;
 import org.psu.miningmanager.dto.MiningShipJob;
 import org.psu.shippurchase.ShipPurchaseJob;
 import org.psu.shippurchase.ShipPurchaseManager;
+import org.psu.shippurchase.ShipPurchaseManager.ShipPurchaseManagerResponse;
+import org.psu.spacetraders.dto.Ship;
 import org.psu.trademanager.TradeShipManager;
 import org.psu.trademanager.dto.TradeShipJob;
 
@@ -29,7 +32,7 @@ public class ShipJobQueueTest {
 	@Test
 	public void emptyQueue() {
 
-		final ShipJobQueue queue = new ShipJobQueue(null, null, null);
+		final ShipJobQueue queue = new ShipJobQueue(null, null, null, null);
 
 		assertThrows(IllegalStateException.class, () -> queue.beginJobQueue());
 	}
@@ -44,14 +47,14 @@ public class ShipJobQueueTest {
 		final TradeShipManager tradeShipManager = mock();
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
-		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager);
+		final ShipJobCreator shipJobCreator = mock();
+		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
+				shipJobCreator);
 
 		final TradeShipJob tradeJob = mock();
 		when(tradeJob.getNextAction()).thenReturn(Instant.now());
 		final MiningShipJob miningJob = mock();
 		when(miningJob.getNextAction()).thenReturn(Instant.now());
-		final ShipPurchaseJob purchaseJob = mock();
-		when(purchaseJob.getNextAction()).thenReturn(Instant.now());
 		final ShipJob otherShipJob = mock();
 		when(otherShipJob.getNextAction()).thenReturn(Instant.now());
 
@@ -60,20 +63,86 @@ public class ShipJobQueueTest {
 		when(laterTradeJob.getNextAction()).thenReturn(oneSecondFromNow);
 		final MiningShipJob laterMiningJob = mock();
 		when(laterMiningJob.getNextAction()).thenReturn(oneSecondFromNow);
-		final ShipPurchaseJob laterPurchaseJob = mock();
-		when(laterPurchaseJob.getNextAction()).thenReturn(oneSecondFromNow);
 
 		// IMPORTANT: Throw an exception on the second iteration to stop us from running
 		// forever
 		when(tradeShipManager.manageTradeShip(tradeJob)).thenReturn(laterTradeJob).thenThrow(RuntimeException.class);
 		when(miningShipManager.manageMiningShip(miningJob)).thenReturn(laterMiningJob)
 				.thenThrow(RuntimeException.class);
-		when(shipPurchaseManager.manageShipPurchase(purchaseJob)).thenReturn(laterPurchaseJob)
-				.thenThrow(RuntimeException.class);
 
-		queue.establishJobs(List.of(tradeJob, miningJob, purchaseJob, otherShipJob));
+		queue.establishJobs(List.of(tradeJob, miningJob, otherShipJob));
 		// By asserting it throws, we ensure that it was called twice
 		assertThrows(RuntimeException.class, () -> queue.beginJobQueue());
+	}
+
+	/**
+	 * Tests the case where a purchase job has not yet been completed
+	 */
+	@Test
+	public void beginJobQueuePurchaseNotDone() {
+
+		final TradeShipManager tradeShipManager = mock();
+		final MiningShipManager miningShipManager = mock();
+		final ShipPurchaseManager shipPurchaseManager = mock();
+		final ShipJobCreator shipJobCreator = mock();
+		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
+				shipJobCreator);
+
+		final ShipPurchaseJob purchaseJob = mock();
+		when(purchaseJob.getNextAction()).thenReturn(Instant.now());
+
+		final ShipPurchaseJob nextJob = mock();
+		when(nextJob.getNextAction()).thenReturn(Instant.now());
+
+		// Job is not done
+		when(shipPurchaseManager.manageShipPurchase(purchaseJob)).thenReturn(new ShipPurchaseManagerResponse(nextJob, null));
+		// Ensures that we don't go on forever
+		when(shipPurchaseManager.manageShipPurchase(nextJob)).thenThrow(IllegalArgumentException.class);
+
+		queue.establishJobs(List.of(purchaseJob));
+		assertThrows(IllegalArgumentException.class, () -> queue.beginJobQueue());
+	}
+
+	/**
+	 * Tests the case where a purchase job has been completed
+	 */
+	@Test
+	public void beginJobQueuePurchaseDone() {
+
+		final TradeShipManager tradeShipManager = mock();
+		final MiningShipManager miningShipManager = mock();
+		final ShipPurchaseManager shipPurchaseManager = mock();
+		final ShipJobCreator shipJobCreator = mock();
+		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
+				shipJobCreator);
+
+		final Ship ship = mock();
+
+		// The original purchase job
+		final ShipPurchaseJob purchaseJob = mock();
+		when(purchaseJob.getShip()).thenReturn(ship);
+		when(purchaseJob.getNextAction()).thenReturn(Instant.now());
+
+		// These are the jobs for the ship which did the purchasing
+		final TradeShipJob nextJob = mock();
+		when(nextJob.getNextAction()).thenReturn(Instant.now().minus(Duration.ofSeconds(1)));
+		final TradeShipJob laterJob = mock();
+		when(laterJob.getNextAction()).thenReturn(Instant.now().plus(Duration.ofSeconds(1)));
+		when(shipJobCreator.createShipJob(ship)).thenReturn(nextJob);
+
+		// This job's next action is after that of nextJob, so it will be processed second
+		final Ship newShip = mock();
+		final MiningShipJob jobForNewShip = mock();
+		when(jobForNewShip.getNextAction()).thenReturn(Instant.now());
+		when(shipJobCreator.createShipJob(newShip)).thenReturn(jobForNewShip);
+
+		when(shipPurchaseManager.manageShipPurchase(purchaseJob)).thenReturn(new ShipPurchaseManagerResponse(null, newShip));
+
+		when(tradeShipManager.manageTradeShip(nextJob)).thenReturn(laterJob);
+		when(miningShipManager.manageMiningShip(jobForNewShip)).thenThrow(IllegalArgumentException.class);
+
+		queue.establishJobs(List.of(purchaseJob));
+		assertThrows(IllegalArgumentException.class, () -> queue.beginJobQueue());
 	}
 
 	/**
@@ -86,7 +155,9 @@ public class ShipJobQueueTest {
 		final TradeShipManager tradeShipManager = mock();
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
-		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager);
+		final ShipJobCreator shipJobCreator = mock();
+		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
+				shipJobCreator);
 
 		final TradeShipJob job = mock(TradeShipJob.class);
 		// Give it enough time that it will have to wait

--- a/java/src/test/java/org/psu/shippurchase/ShipPurchaseManagerTest.java
+++ b/java/src/test/java/org/psu/shippurchase/ShipPurchaseManagerTest.java
@@ -15,10 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.psu.init.ShipJobCreator;
 import org.psu.navigation.NavigationPath;
 import org.psu.navigation.RefuelPathCalculator;
-import org.psu.shiporchestrator.ShipJob;
+import org.psu.shippurchase.ShipPurchaseManager.ShipPurchaseManagerResponse;
 import org.psu.spacetraders.api.MarketplaceRequester;
 import org.psu.spacetraders.api.NavigationHelper;
 import org.psu.spacetraders.dto.Ship;
@@ -46,9 +45,6 @@ public class ShipPurchaseManagerTest {
 
 	@Mock
 	private MarketplaceRequester marketplaceRequester;
-
-	@Mock
-	private ShipJobCreator shipJobCreator;
 
 	@InjectMocks
 	private ShipPurchaseManager shipPurchaseManager;
@@ -126,18 +122,15 @@ public class ShipPurchaseManagerTest {
 		final ShipPurchaseResponse response = mock();
 		when(response.getShip()).thenReturn(newShip);
 
-		final ShipJob newJob = mock();
-
-		when(shipJobCreator.createShipJob(newShip)).thenReturn(newJob);
-
 		final ShipPurchaseRequest expectedPurchaseRequest = new ShipPurchaseRequest(shipType, shipyardId);
 		when(shipyardManager.purchaseShip(expectedPurchaseRequest)).thenReturn(response);
 
 		final ShipPurchaseJob job = new ShipPurchaseJob(ship, path, shipyard, shipType, Instant.now());
 
-		final ShipJob nextJob = shipPurchaseManager.manageShipPurchase(job);
+		final ShipPurchaseManagerResponse managerResponse = shipPurchaseManager.manageShipPurchase(job);
 
-		assertEquals(newJob, nextJob);
+		assertEquals(newShip, managerResponse.newShip());
+		assertNull(managerResponse.nextJob());
 
 		verify(navigationHelper).dock(ship);
 	}
@@ -164,18 +157,15 @@ public class ShipPurchaseManagerTest {
 		final ShipPurchaseResponse response = mock();
 		when(response.getShip()).thenReturn(newShip);
 
-		final ShipJob newJob = mock();
-
-		when(shipJobCreator.createShipJob(newShip)).thenReturn(newJob);
-
 		final ShipPurchaseRequest expectedPurchaseRequest = new ShipPurchaseRequest(shipType, shipyardId);
 		when(shipyardManager.purchaseShip(expectedPurchaseRequest)).thenReturn(response);
 
 		final ShipPurchaseJob job = new ShipPurchaseJob(ship, path, shipyard, shipType, Instant.now());
 
-		final ShipJob nextJob = shipPurchaseManager.manageShipPurchase(job);
+		final ShipPurchaseManagerResponse managerResponse = shipPurchaseManager.manageShipPurchase(job);
 
-		assertEquals(newJob, nextJob);
+		assertEquals(newShip, managerResponse.newShip());
+		assertNull(managerResponse.nextJob());
 
 		verify(navigationHelper).dock(ship);
 	}
@@ -203,9 +193,10 @@ public class ShipPurchaseManagerTest {
 
 		final ShipPurchaseJob job = new ShipPurchaseJob(ship, path, shipyard, shipType, Instant.now());
 
-		final ShipJob nextJob = shipPurchaseManager.manageShipPurchase(job);
+		final ShipPurchaseManagerResponse managerResponse = shipPurchaseManager.manageShipPurchase(job);
 
-		assertEquals(nextAction, nextJob.getNextAction());
+		assertNull(managerResponse.newShip());
+		assertEquals(nextAction, managerResponse.nextJob().getNextAction());
 		verify(marketplaceRequester).refuel(ship);
 	}
 

--- a/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
+++ b/java/src/test/java/org/psu/trademanager/TradeShipManagerTest.java
@@ -1,6 +1,7 @@
 package org.psu.trademanager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -270,13 +271,6 @@ public class TradeShipManagerTest {
 		final MarketInfo marketInfo = mock(MarketInfo.class);
 		when(marketManager.updateMarketInfo(importWaypoint)).thenReturn(marketInfo);
 
-		final TradeRoute newTradeRoute = mock();
-		final Waypoint way = mock();
-		final Queue<Waypoint> ways = new LinkedList<>();
-		ways.add(way);
-		final RouteResponse routeResponse = new RouteResponse(newTradeRoute, ways);
-		when(routeManager.getBestRoute(ship)).thenReturn(routeResponse);
-
 		final TradeShipJob job = new TradeShipJob(ship, tradeRoute, new LinkedList<>());
 		job.setState(State.TRAVELING);
 
@@ -285,9 +279,7 @@ public class TradeShipManagerTest {
 		final TradeShipJob outputJob = manager.manageTradeShip(job);
 
 		verify(marketRequester).dockAndSellItems(ship, importWaypoint, List.of(cargoItem));
-		assertEquals(State.NOT_STARTED, outputJob.getState());
-		assertEquals(ship, outputJob.getShip());
-		assertEquals(newTradeRoute, outputJob.getRoute());
+		assertNull(outputJob);
 	}
 
 }


### PR DESCRIPTION
Ship managers are no longer responsible for creating the next jobs for their ships. This change is needed because the job queue is going to start creating ship purchase jobs if needed.