### PR TITLE
Report new ship

### DIFF
--- a/java/src/main/java/org/psu/websocket/WebsocketReporter.java
+++ b/java/src/main/java/org/psu/websocket/WebsocketReporter.java
@@ -70,6 +70,13 @@ public class WebsocketReporter {
 		}
 	}
 
+    public void addShip(final Ship ship) {
+    	this.ships.add(ship);
+		for (Session session : this.sessions) {
+			sendShipUpdate(session);
+		}
+    }
+
     private void sendCreditUpdate(final Session session) {
     	final CreditMessage creditMessage = new CreditMessage(this.creditTotal);
         session.getAsyncRemote().sendObject(creditMessage);

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -10,7 +10,7 @@ app.throttler.rate-limiters[1].period=60
 
 %test-driver.app.marketupdate-delay-ms=0
 %test-driver.app.throttler.enabled=false
-app.test-driver.nav-time-ms-per-unit=2
+app.test-driver.nav-time-ms-per-unit=5
 app.test-driver.extraction-cooldown-s=1
 
 quarkus.http.cors=true

--- a/java/src/test/java/org/psu/shiporchestrator/ShipJobQueueTest.java
+++ b/java/src/test/java/org/psu/shiporchestrator/ShipJobQueueTest.java
@@ -2,6 +2,7 @@ package org.psu.shiporchestrator;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
@@ -21,6 +22,7 @@ import org.psu.spacetraders.dto.Ship;
 import org.psu.spacetraders.dto.ShipType;
 import org.psu.trademanager.TradeShipManager;
 import org.psu.trademanager.dto.TradeShipJob;
+import org.psu.websocket.WebsocketReporter;
 
 /**
  * Tests for {@link ShipJobQueue}
@@ -33,7 +35,7 @@ public class ShipJobQueueTest {
 	@Test
 	public void emptyQueue() {
 
-		final ShipJobQueue queue = new ShipJobQueue(null, null, null, null);
+		final ShipJobQueue queue = new ShipJobQueue(null, null, null, null, null);
 
 		assertThrows(IllegalStateException.class, () -> queue.beginJobQueue());
 	}
@@ -49,8 +51,9 @@ public class ShipJobQueueTest {
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
 		final ShipJobCreator shipJobCreator = mock();
+		final WebsocketReporter websocketReporter = mock();
 		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
-				shipJobCreator);
+				shipJobCreator, websocketReporter);
 
 		final TradeShipJob tradeJob = mock();
 		when(tradeJob.getNextAction()).thenReturn(Instant.now());
@@ -86,8 +89,9 @@ public class ShipJobQueueTest {
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
 		final ShipJobCreator shipJobCreator = mock();
+		final WebsocketReporter websocketReporter = mock();
 		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
-				shipJobCreator);
+				shipJobCreator, websocketReporter);
 
 		final ShipPurchaseJob purchaseJob = mock();
 		when(purchaseJob.getNextAction()).thenReturn(Instant.now());
@@ -114,8 +118,9 @@ public class ShipJobQueueTest {
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
 		final ShipJobCreator shipJobCreator = mock();
+		final WebsocketReporter websocketReporter = mock();
 		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
-				shipJobCreator);
+				shipJobCreator, websocketReporter);
 
 		final Ship ship = mock();
 
@@ -145,6 +150,7 @@ public class ShipJobQueueTest {
 
 		queue.establishJobs(List.of(purchaseJob));
 		assertThrows(IllegalArgumentException.class, () -> queue.beginJobQueue());
+		verify(websocketReporter).addShip(newShip);
 	}
 
 	/**
@@ -157,8 +163,9 @@ public class ShipJobQueueTest {
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
 		final ShipJobCreator shipJobCreator = mock();
+		final WebsocketReporter websocketReporter = mock();
 		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
-				shipJobCreator);
+				shipJobCreator, websocketReporter);
 
 		final Ship ship = mock();
 
@@ -195,8 +202,9 @@ public class ShipJobQueueTest {
 		final MiningShipManager miningShipManager = mock();
 		final ShipPurchaseManager shipPurchaseManager = mock();
 		final ShipJobCreator shipJobCreator = mock();
+		final WebsocketReporter websocketReporter = mock();
 		final ShipJobQueue queue = new ShipJobQueue(miningShipManager, tradeShipManager, shipPurchaseManager,
-				shipJobCreator);
+				shipJobCreator, websocketReporter);
 
 		final TradeShipJob job = mock(TradeShipJob.class);
 		// Give it enough time that it will have to wait


### PR DESCRIPTION
Sends a websocket message when a new ship is purchased.

Also fixes a bug where the job queue would drop jobs when their next actions were identical.